### PR TITLE
Forward screen configuration flag

### DIFF
--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Appboy"
-    s.version          = "6.12.5"
+    s.version          = "6.12.6"
     s.summary          = "Appboy integration for mParticle"
 
     s.description      = <<-DESC
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-Appboy/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.12.4'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.12.6'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
     s.ios.dependency 'Appboy-iOS-SDK', '2.27.0'


### PR DESCRIPTION
The `forwardScreenViews` flag indicates whether `logScreen` should be forwarded to Appboy. It defaults to `NO`.