### PR TITLE
Remove old mechanism for setting Appboy endpoint

### DIFF
--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -42,11 +42,7 @@
 NSString *const eabAPIKey = @"apiKey";
 NSString *const eabOptions = @"options";
 NSString *const hostConfigKey = @"host";
-NSString *const dataCenterLocationConfigKey = @"dataCenterLocation";
-NSString *const usDataCenterLocation = @"US";
-NSString *const euDataCenterLocation = @"EU";
 NSString *const originalHost = @"dev.appboy.com";
-NSString *const euHost = @"sdk.api.appboy.eu";
 
 static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = nil;
 
@@ -57,7 +53,6 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
 }
 
 @property (nonatomic) NSString *host;
-@property (nonatomic) NSString *dataCenterLocation;
 
 @end
 
@@ -207,11 +202,6 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
 #pragma mark ABKAppboyEndpointDelegate
 - (NSString *)getApiEndpoint:(NSString *)appboyApiEndpoint {
     NSString *host = self.host;
-    
-    if (!host.length) {
-        host = euHost;
-    }
-    
     NSString *endpoint = [appboyApiEndpoint stringByReplacingOccurrencesOfString:originalHost withString:host];
     return endpoint;
 }
@@ -228,7 +218,6 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
     collectIDFA = NO;
     forwardScreenViews = NO;
     _host = configuration[hostConfigKey];
-    _dataCenterLocation = configuration[dataCenterLocationConfigKey];
 
     if (startImmediately) {
         [self start];
@@ -268,7 +257,7 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
 #pragma clang diagnostic pop
         }
         
-        if (self.host.length || (self.dataCenterLocation && [self.dataCenterLocation isEqualToString:euDataCenterLocation])) {
+        if (self.host.length) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
             optionsDictionary[ABKAppboyEndpointDelegateKey] = self;


### PR DESCRIPTION
Here is a summary of the new behavior:

If the config key `host` exists and its value has a non-zero length, value, we will set the Appboy endpoint delegate when we start Appboy.

Inside the endpoint delegate method, we get passed the current endpoint string. Per their docs, we will perform a search and replace on the endpoint string, replacing the hardcoded value `dev.appboy.com` with the host string from kit config.

If `host` is nil or empty, we will not set the endpoint delegate.