### PR TITLE
Allow Braze kit to set mParticleGenderNotAvailable

### DIFF
--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -480,7 +480,14 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
     } else if ([key isEqualToString:mParticleUserAttributeCity]) {
         appboyInstance.user.homeCity = value;
     } else if ([key isEqualToString:mParticleUserAttributeGender]) {
-        appboyInstance.user.gender = [value isEqualToString:mParticleGenderMale] ? ABKUserGenderMale : ABKUserGenderFemale;
+        appboyInstance.user.gender = ABKUserGenderOther;
+        if ([value isEqualToString:mParticleGenderMale]) {
+            appboyInstance.user.gender = ABKUserGenderMale;
+        } else if ([value isEqualToString:mParticleGenderFemale]) {
+            appboyInstance.user.gender = ABKUserGenderFemale;
+        } else if ([value isEqualToString:mParticleGenderNotAvailable]) {
+            appboyInstance.user.gender = ABKUserGenderNotApplicable;
+        }
     } else if ([key isEqualToString:mParticleUserAttributeMobileNumber] || [key isEqualToString:@"$MPUserMobile"]) {
         appboyInstance.user.phone = value;
     } else {


### PR DESCRIPTION
Currently there is no way to set gender in Braze kit as anything other than ABKUserGenderMale and ABKUserGenderFemale. We should allow the user to set ABKUserGenderNotApplicable and also not default to Female.

If gender is set to something that is not an mParticle gender enum then
default to ABKUserGenderOther