### PR TITLE
Update Braze Location Tracking

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Appboy/appboy-ios-sdk" "3.5.1"
-github "mparticle/mparticle-apple-sdk" "7.3.7"
+github "mparticle/mparticle-apple-sdk" "7.3.8"

--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -280,6 +280,13 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
           optionsDictionary[ABKSDKFlavorKey] = @(MPARTICLE);
 #pragma clang diagnostic pop
         }
+        
+        optionsDictionary[ABKDisableAutomaticLocationCollectionKey] = @(NO);
+        if (self.configuration[@"ABKDisableAutomaticLocationCollectionKey"]) {
+            if ([self.configuration[@"ABKDisableAutomaticLocationCollectionKey"] caseInsensitiveCompare:@"true"] == NSOrderedSame) {
+                optionsDictionary[ABKDisableAutomaticLocationCollectionKey] = @(YES);
+            }
+        }
 
         [Appboy startWithApiKey:self.configuration[eabAPIKey]
                   inApplication:[UIApplication sharedApplication]


### PR DESCRIPTION
Braze's location tracking is on by default. We have added a new boolean setting such that customers can use to turn it off remotely. The new setting is ABKDisableAutomaticLocationCollectionKey. This change update the kit to listen to that configuration.