### PR TITLE
Prevent possible crash if braze sdk is disabled

### DIFF
--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -245,6 +245,9 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
               withLaunchOptions:self.launchOptions
               withAppboyOptions:optionsDict];
 
+        if (![Appboy sharedInstance] ) {
+            return;
+        }
         CFTypeRef appboyRef = CFRetain((__bridge CFTypeRef)[Appboy sharedInstance]);
         self->appboyInstance = (__bridge Appboy *)appboyRef;
 


### PR DESCRIPTION
This PR makes it so that if the Braze SDK is disabled prior to mParticle's SDK start, it will not be added as an active kit and won't crash on the line immediately after this.

That said - I think a more comprehensive change would account for the Braze SDK being disable at any time. I believe the Braze kit today maintains a reference to Braze's instance due to a long-past bug in the Braze SDK and should likely be refactored to de-initialize or just otherwise release the reference and not crash if a customer called the `disable` API at any moment.