### PR TITLE
Support InAppMessageControllerDelegate

### DIFF
--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -255,6 +255,10 @@ static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = ni
             self->appboyInstance.idfaDelegate = (id)self;
         }
 
+        if ([MPKitAppboy inAppMessageControllerDelegate]) {
+            self->appboyInstance.inAppMessageController.delegate = [MPKitAppboy inAppMessageControllerDelegate]
+        }
+
         self->_started = YES;
 
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Problem:
While attempting to leverage inAppMessageControllerDelegate, I noticed I was not able to get Delegate Callbacks.

Investigation:
Noticed that although a static member was declared for inAppMessageControllerDelegate, this value was never used

Change:
If the static delegate member is set before the SharedInstance is initialized, pass into iVar delegate.

There's likely many more optimizations to support changing. As well as updating the delegate to be weak instead of strong? But wanted to get the ball rolling on this with eyes that are more aware of the models/functionality (honestly even objc styling here)