### PR TITLE
Update API usage for Braze SDK version 3.17.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Appboy/appboy-ios-sdk" ~> 3.0
+github "Appboy/appboy-ios-sdk" ~> 3.17
 github "mparticle/mparticle-apple-sdk" ~> 7.10.0

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -13,18 +13,18 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-appboy.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticle"
 
-    s.ios.deployment_target = "8.0"
+    s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Appboy/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Appboy-iOS-SDK', '~> 3.0'
+    s.ios.dependency 'Appboy-iOS-SDK', '~> 3.17'
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-Appboy/*.{h,m,mm}'
     s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
     s.tvos.frameworks = 'SystemConfiguration'
-    s.tvos.dependency 'Appboy-tvOS-SDK', '~> 3.0'
+    s.tvos.dependency 'Appboy-tvOS-SDK', '~> 3.17'
     
     s.tvos.pod_target_xcconfig = {
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Appboy-tvOS-SDK/**'

--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -32,7 +32,7 @@ NSString *const hostConfigKey = @"host";
 
 __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = nil;
 
-@interface MPKitAppboy() <ABKAppboyEndpointDelegate> {
+@interface MPKitAppboy() {
     Appboy *appboyInstance;
     BOOL collectIDFA;
     BOOL forwardScreenViews;
@@ -189,22 +189,6 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     return _advertiserId;
 }
 
-#pragma mark ABKAppboyEndpointDelegate
-- (NSString *)getApiEndpoint:(NSString *)appboyApiEndpoint {
-    NSMutableString *modifiedEndpoint = [appboyApiEndpoint mutableCopy];
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:
-                                  @"https.*\\.com" options:0 error:nil];
-    
-    if (self.host && modifiedEndpoint) {
-        [regex replaceMatchesInString:modifiedEndpoint options:0 range:NSMakeRange(0, [modifiedEndpoint length]) withTemplate:self.host];
-        if (![modifiedEndpoint containsString:@"https://"] && ![modifiedEndpoint containsString:@"http://"]) {
-            modifiedEndpoint = [NSMutableString stringWithFormat:@"https://%@", modifiedEndpoint];
-        }
-    }
-    
-    return [modifiedEndpoint copy];
-}
-
 #pragma mark MPKitInstanceProtocol methods
 - (MPKitExecStatus *)didFinishLaunchingWithConfiguration:(NSDictionary *)configuration {
     MPKitExecStatus *execStatus = nil;
@@ -302,7 +286,7 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     if (self.host.length) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
-        optionsDictionary[ABKAppboyEndpointDelegateKey] = (id)self;
+        optionsDictionary[ABKEndpointKey] = self.host;
 #pragma clang diagnostic pop
     }
     


### PR DESCRIPTION
Note: if you are using Braze <= 3.16.0, these changes will cause compiler
errors due to breaking changes to the Braze SDK. You can either update
Braze or continue to depend on version 7.10.5 of the mParticle kit.