### PR TITLE
Stricter Appboy-iOS-SDK dependency

### DIFF
--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.11.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Appboy-iOS-SDK', '~> 3.20'
+    s.ios.dependency 'Appboy-iOS-SDK/Core', '~> 3.20'
     
     s.tvos.pod_target_xcconfig = {
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Appboy-tvOS-SDK/**'


### PR DESCRIPTION
The framework seems to have some unneeded dependencies. By requiring all of `Appboy-iOS-SDK`, you're requiring consumers of the pod to bundle extra frameworks that never get used (and can cause build issues, namely with [SDWebImage](https://github.com/CocoaPods/CocoaPods/issues/8206)).

`Appboy-iOS-SDK/Core` seems to be the part it actually requires. Please close if this is incorrect.
