### PR TITLE
Use a binary for Appboy SDK with Carthage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Appboy/appboy-ios-sdk" ~> 3.20
+binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk.json" ~> 3.20
 github "mparticle/mparticle-apple-sdk" ~> 7.11.0


### PR DESCRIPTION
The Appboy SDK is not supported for Carthage source distribution, only as a pre-built binary.
See this comment for their suggested way to integrate it in a Cartfile: https://github.com/Appboy/appboy-ios-sdk/issues/85

See also, their README: https://github.com/Appboy/appboy-ios-sdk#version-support
