### PR TITLE
Respect UserIdentificationType in KitConfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-osx_image: xcode9.3
+osx_image: xcode11
 language: objective-c
 script:
-- sudo gem install cocoapods -v 1.5.0
+- sudo gem install cocoapods -v 1.8.4
 - travis_retry pod repo update > /dev/null
 - pod lib lint --use-libraries --allow-warnings || pod lib lint --allow-warnings

--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -17,18 +17,29 @@
         #endif
     #endif
 #else
-
-#if TARGET_OS_IOS == 1
-#import <Appboy_iOS_SDK/Appboy-iOS-SDK-umbrella.h>
-#elif TARGET_OS_TV == 1
-#import "AppboyKit.h"
+    #if TARGET_OS_IOS == 1
+        #import <Appboy_iOS_SDK/Appboy-iOS-SDK-umbrella.h>
+    #elif TARGET_OS_TV == 1
+        #import "AppboyKit.h"
+    #endif
 #endif
 
-#endif
+static NSString *const eabAPIKey = @"apiKey";
+static NSString *const eabOptions = @"options";
+static NSString *const hostConfigKey = @"host";
+static NSString *const userIdTypeKey = @"userIdentificationType";
 
-NSString *const eabAPIKey = @"apiKey";
-NSString *const eabOptions = @"options";
-NSString *const hostConfigKey = @"host";
+// The possible values for userIdentificationType
+static NSString *const userIdValueOther = @"Other";
+static NSString *const userIdValueCustomerId = @"CustomerId";
+static NSString *const userIdValueFacebook = @"Facebook";
+static NSString *const userIdValueTwitter = @"Twitter";
+static NSString *const userIdValueGoogle = @"Google";
+static NSString *const userIdValueMicrosoft = @"Microsoft";
+static NSString *const userIdValueYahoo = @"Yahoo";
+static NSString *const userIdValueEmail = @"Email";
+static NSString *const userIdValueAlias = @"Alias";
+static NSString *const userIdValueMPID = @"MPID";
 
 __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = nil;
 
@@ -39,6 +50,7 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
 }
 
 @property (nonatomic) NSString *host;
+@property (nonatomic) MPUserIdentity userIdType;
 
 @end
 
@@ -202,7 +214,9 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     _started = NO;
     collectIDFA = NO;
     forwardScreenViews = NO;
+    
     _host = configuration[hostConfigKey];
+    _userIdType = [self userIdentityForString:configuration[userIdTypeKey]];
     
     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;
@@ -301,7 +315,7 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     }
     optionsDictionary[ABKSDKFlavorKey] = @(MPARTICLE);
 #pragma clang diagnostic pop
-
+    
 #if TARGET_OS_IOS == 1
     optionsDictionary[ABKEnableAutomaticLocationCollectionKey] = @(YES);
     if (self.configuration[@"ABKDisableAutomaticLocationCollectionKey"]) {
@@ -575,10 +589,70 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     
     if (request.userIdentities) {
         NSMutableDictionary *userIDsCopy = [request.userIdentities copy];
+        NSString *userId;
         
-        if (userIDsCopy[@(MPUserIdentityCustomerId)]) {
+        switch (_userIdType) {
+            case MPUserIdentityOther:
+                if (userIDsCopy[@(MPUserIdentityOther)]) {
+                    userId = userIDsCopy[@(MPUserIdentityOther)];
+                }
+                break;
+            case MPUserIdentityCustomerId:
+                if (userIDsCopy[@(MPUserIdentityCustomerId)]) {
+                    userId = userIDsCopy[@(MPUserIdentityCustomerId)];
+                }
+                break;
+            case MPUserIdentityFacebook:
+                if (userIDsCopy[@(MPUserIdentityFacebook)]) {
+                    userId = userIDsCopy[@(MPUserIdentityFacebook)];
+                }
+                break;
+            case MPUserIdentityTwitter:
+                if (userIDsCopy[@(MPUserIdentityTwitter)]) {
+                    userId = userIDsCopy[@(MPUserIdentityTwitter)];
+                }
+                break;
+            case MPUserIdentityGoogle:
+                if (userIDsCopy[@(MPUserIdentityGoogle)]) {
+                    userId = userIDsCopy[@(MPUserIdentityGoogle)];
+                }
+                break;
+            case MPUserIdentityMicrosoft:
+                if (userIDsCopy[@(MPUserIdentityMicrosoft)]) {
+                    userId = userIDsCopy[@(MPUserIdentityMicrosoft)];
+                }
+                break;
+            case MPUserIdentityYahoo:
+                if (userIDsCopy[@(MPUserIdentityYahoo)]) {
+                    userId = userIDsCopy[@(MPUserIdentityYahoo)];
+                }
+                break;
+            case MPUserIdentityEmail:
+                if (userIDsCopy[@(MPUserIdentityEmail)]) {
+                    userId = userIDsCopy[@(MPUserIdentityEmail)];
+                }
+                break;
+            case MPUserIdentityAlias:
+                if (userIDsCopy[@(MPUserIdentityAlias)]) {
+                    userId = userIDsCopy[@(MPUserIdentityAlias)];
+                }
+                break;
+            case MPUserIdentityOther4:
+                if (user != nil) {
+                    userId = user.userId.stringValue;
+                }
+                break;
+                
+            default:
+                if (userIDsCopy[@(MPUserIdentityCustomerId)]) {
+                    userId = userIDsCopy[@(MPUserIdentityCustomerId)];
+                }
+                break;
+        }
+        
+        if (userId) {
             void (^changeUser)(void) = ^ {
-                [self->appboyInstance changeUser:userIDsCopy[@(MPUserIdentityCustomerId)]];
+                [self->appboyInstance changeUser:userId];
             };
             
             if ([NSThread isMainThread]) {
@@ -610,5 +684,33 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     return execStatus;
 }
 #endif
+
+- (MPUserIdentity)userIdentityForString:(nullable NSString *)userIdString {
+    if (userIdString != nil) {
+        if ([userIdString isEqualToString:userIdValueOther]) {
+            return MPUserIdentityOther;
+        } else if ([userIdString isEqualToString:userIdValueCustomerId]) {
+            return MPUserIdentityCustomerId;
+        } else if ([userIdString isEqualToString:userIdValueFacebook]) {
+            return MPUserIdentityFacebook;
+        } else if ([userIdString isEqualToString:userIdValueTwitter]) {
+            return MPUserIdentityTwitter;
+        } else if ([userIdString isEqualToString:userIdValueGoogle]) {
+            return MPUserIdentityGoogle;
+        } else if ([userIdString isEqualToString:userIdValueMicrosoft]) {
+            return MPUserIdentityMicrosoft;
+        } else if ([userIdString isEqualToString:userIdValueYahoo]) {
+            return MPUserIdentityYahoo;
+        } else if ([userIdString isEqualToString:userIdValueEmail]) {
+            return MPUserIdentityEmail;
+        } else if ([userIdString isEqualToString:userIdValueAlias]) {
+            return MPUserIdentityAlias;
+        } else if ([userIdString isEqualToString:userIdValueMPID]) {
+            return MPUserIdentityOther4;
+        }
+    }
+    
+    return MPUserIdentityCustomerId;
+}
 
 @end

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -14,7 +14,9 @@
 #import "AppboyKit.h"
 #endif
 
-@interface MPKitAppboy () <ABKAppboyEndpointDelegate>
+@interface MPKitAppboy ()
+
+@property (nonatomic) MPUserIdentity userIdType;
 
 - (NSMutableDictionary<NSString *, NSNumber *> *)optionsDictionary;
 + (id<ABKInAppMessageControllerDelegate>)inAppMessageControllerDelegate;
@@ -46,8 +48,8 @@
     
     [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    NSDictionary *testOptionsDictionary = @{ABKDisableAutomaticLocationCollectionKey:@(NO),
-                                            ABKSDKFlavorKey:@6
+    NSDictionary *testOptionsDictionary = @{ABKEnableAutomaticLocationCollectionKey:@(YES),
+                                            ABKSDKFlavorKey:@7
                                        };
     
     NSDictionary *optionsDictionary = [appBoy optionsDictionary];
@@ -64,13 +66,14 @@
                                        @"ABKFlushIntervalOptionKey":@"2",
                                        @"ABKSessionTimeoutKey":@"3",
                                        @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
+                                       @"ABKCollectIDFA":@"true",
+                                       @"userIdentificationType":@"CustomerId"
                                        };
     
     [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    NSDictionary *testOptionsDictionary = @{ABKDisableAutomaticLocationCollectionKey:@(NO),
-                                            ABKSDKFlavorKey:@6,
+    NSDictionary *testOptionsDictionary = @{ABKEnableAutomaticLocationCollectionKey:@(YES),
+                                            ABKSDKFlavorKey:@7,
                                             ABKIDFADelegateKey: appBoy,
                                             @"ABKRquestProcessingPolicy": @(1),
                                             @"ABKFlushInterval":@(2),
@@ -82,164 +85,164 @@
     XCTAssertEqualObjects(optionsDictionary, testOptionsDictionary);
 }
 
-- (void)testEndpointOverride {
-    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
-    
-    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
-                                       @"host":@"https://foo.bar.com",
-                                       @"id":@42,
-                                       @"ABKCollectIDFA":@"true",
-                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
-                                       @"ABKFlushIntervalOptionKey":@"2",
-                                       @"ABKSessionTimeoutKey":@"3",
-                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
-                                       };
-    
-    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
-    
-    XCTAssertEqualObjects(@"https://foo.bar.com", [appBoy getApiEndpoint:@"https://original.com"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
-    
-    NSString *testEndpoint;
-    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
-    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
-    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
-}
-
-- (void)testEndpointOverride2 {
-    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
-    
-    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
-                                       @"host":@"http://foo.bar.com",
-                                       @"id":@42,
-                                       @"ABKCollectIDFA":@"true",
-                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
-                                       @"ABKFlushIntervalOptionKey":@"2",
-                                       @"ABKSessionTimeoutKey":@"3",
-                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
-                                       };
-    
-    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
-    
-    XCTAssertEqualObjects(@"http://foo.bar.com", [appBoy getApiEndpoint:@"https://original.com"]);
-    XCTAssertEqualObjects(@"http://foo.bar.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
-    XCTAssertEqualObjects(@"http://foo.bar.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
-    
-    NSString *testEndpoint;
-    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
-    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
-    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
-}
-
-- (void)testEndpointOverride3 {
-    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
-    
-    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
-                                       @"host":@"foo.bar.com",
-                                       @"id":@42,
-                                       @"ABKCollectIDFA":@"true",
-                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
-                                       @"ABKFlushIntervalOptionKey":@"2",
-                                       @"ABKSessionTimeoutKey":@"3",
-                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
-                                       };
-    
-    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
-    
-    XCTAssertEqualObjects(@"https://foo.bar.com", [appBoy getApiEndpoint:@"https://original.com"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
-    
-    
-    NSString *testEndpoint;
-    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
-    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
-    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
-}
-
-- (void)testEndpointOverride4 {
-    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
-    
-    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
-                                       @"host":@"https://foo.bar.com/baz",
-                                       @"id":@42,
-                                       @"ABKCollectIDFA":@"true",
-                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
-                                       @"ABKFlushIntervalOptionKey":@"2",
-                                       @"ABKSessionTimeoutKey":@"3",
-                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
-                                       };
-    
-    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
-    
-    XCTAssertEqualObjects(@"https://foo.bar.com/baz", [appBoy getApiEndpoint:@"https://original.com"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/baz/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/baz/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
-    
-    
-    NSString *testEndpoint;
-    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
-    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
-    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
-}
-
-- (void)testEndpointOverride5 {
-    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
-    
-    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
-                                       @"host":@"https://foo.bar.com/baz/baz",
-                                       @"id":@42,
-                                       @"ABKCollectIDFA":@"true",
-                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
-                                       @"ABKFlushIntervalOptionKey":@"2",
-                                       @"ABKSessionTimeoutKey":@"3",
-                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
-                                       };
-    
-    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
-    
-    XCTAssertEqualObjects(@"https://foo.bar.com/baz/baz", [appBoy getApiEndpoint:@"https://original.com"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/baz/baz/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
-    XCTAssertEqualObjects(@"https://foo.bar.com/baz/baz/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
-    
-    
-    NSString *testEndpoint;
-    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
-    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
-    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
-}
-
-- (void)testEndpointOverrideNilHost {
-    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
-    
-    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
-                                       @"id":@42,
-                                       @"ABKCollectIDFA":@"true",
-                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
-                                       @"ABKFlushIntervalOptionKey":@"2",
-                                       @"ABKSessionTimeoutKey":@"3",
-                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
-                                       @"ABKCollectIDFA":@"true"
-                                       };
-    
-    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
-    
-    XCTAssertEqualObjects(@"https://original.com", [appBoy getApiEndpoint:@"https://original.com"]);
-    XCTAssertEqualObjects(@"https://original.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
-    XCTAssertEqualObjects(@"https://original.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
-    
-    
-    NSString *testEndpoint;
-    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
-    XCTAssertEqualObjects(@"moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
-    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
-}
+//- (void)testEndpointOverride {
+//    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+//
+//    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+//                                       @"host":@"https://foo.bar.com",
+//                                       @"id":@42,
+//                                       @"ABKCollectIDFA":@"true",
+//                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+//                                       @"ABKFlushIntervalOptionKey":@"2",
+//                                       @"ABKSessionTimeoutKey":@"3",
+//                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+//                                       @"ABKCollectIDFA":@"true"
+//                                       };
+//
+//    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+//
+//    XCTAssertEqualObjects(@"https://foo.bar.com", [appBoy getApiEndpoint:@"https://original.com"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
+//
+//    NSString *testEndpoint;
+//    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
+//    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
+//    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
+//}
+//
+//- (void)testEndpointOverride2 {
+//    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+//
+//    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+//                                       @"host":@"http://foo.bar.com",
+//                                       @"id":@42,
+//                                       @"ABKCollectIDFA":@"true",
+//                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+//                                       @"ABKFlushIntervalOptionKey":@"2",
+//                                       @"ABKSessionTimeoutKey":@"3",
+//                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+//                                       @"ABKCollectIDFA":@"true"
+//                                       };
+//
+//    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+//
+//    XCTAssertEqualObjects(@"http://foo.bar.com", [appBoy getApiEndpoint:@"https://original.com"]);
+//    XCTAssertEqualObjects(@"http://foo.bar.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
+//    XCTAssertEqualObjects(@"http://foo.bar.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
+//
+//    NSString *testEndpoint;
+//    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
+//    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
+//    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
+//}
+//
+//- (void)testEndpointOverride3 {
+//    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+//
+//    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+//                                       @"host":@"foo.bar.com",
+//                                       @"id":@42,
+//                                       @"ABKCollectIDFA":@"true",
+//                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+//                                       @"ABKFlushIntervalOptionKey":@"2",
+//                                       @"ABKSessionTimeoutKey":@"3",
+//                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+//                                       @"ABKCollectIDFA":@"true"
+//                                       };
+//
+//    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+//
+//    XCTAssertEqualObjects(@"https://foo.bar.com", [appBoy getApiEndpoint:@"https://original.com"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
+//
+//
+//    NSString *testEndpoint;
+//    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
+//    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
+//    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
+//}
+//
+//- (void)testEndpointOverride4 {
+//    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+//
+//    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+//                                       @"host":@"https://foo.bar.com/baz",
+//                                       @"id":@42,
+//                                       @"ABKCollectIDFA":@"true",
+//                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+//                                       @"ABKFlushIntervalOptionKey":@"2",
+//                                       @"ABKSessionTimeoutKey":@"3",
+//                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+//                                       @"ABKCollectIDFA":@"true"
+//                                       };
+//
+//    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+//
+//    XCTAssertEqualObjects(@"https://foo.bar.com/baz", [appBoy getApiEndpoint:@"https://original.com"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/baz/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/baz/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
+//
+//
+//    NSString *testEndpoint;
+//    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
+//    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
+//    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
+//}
+//
+//- (void)testEndpointOverride5 {
+//    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+//
+//    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+//                                       @"host":@"https://foo.bar.com/baz/baz",
+//                                       @"id":@42,
+//                                       @"ABKCollectIDFA":@"true",
+//                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+//                                       @"ABKFlushIntervalOptionKey":@"2",
+//                                       @"ABKSessionTimeoutKey":@"3",
+//                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+//                                       @"ABKCollectIDFA":@"true"
+//                                       };
+//
+//    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+//
+//    XCTAssertEqualObjects(@"https://foo.bar.com/baz/baz", [appBoy getApiEndpoint:@"https://original.com"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/baz/baz/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
+//    XCTAssertEqualObjects(@"https://foo.bar.com/baz/baz/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
+//
+//
+//    NSString *testEndpoint;
+//    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
+//    XCTAssertEqualObjects(@"https://moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
+//    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
+//}
+//
+//- (void)testEndpointOverrideNilHost {
+//    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+//
+//    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+//                                       @"id":@42,
+//                                       @"ABKCollectIDFA":@"true",
+//                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+//                                       @"ABKFlushIntervalOptionKey":@"2",
+//                                       @"ABKSessionTimeoutKey":@"3",
+//                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+//                                       @"ABKCollectIDFA":@"true"
+//                                       };
+//
+//    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+//
+//    XCTAssertEqualObjects(@"https://original.com", [appBoy getApiEndpoint:@"https://original.com"]);
+//    XCTAssertEqualObjects(@"https://original.com/param1", [appBoy getApiEndpoint:@"https://original.com/param1"]);
+//    XCTAssertEqualObjects(@"https://original.com/param1/param2", [appBoy getApiEndpoint:@"https://original.com/param1/param2"]);
+//
+//
+//    NSString *testEndpoint;
+//    XCTAssertNil([appBoy getApiEndpoint:testEndpoint]);
+//    XCTAssertEqualObjects(@"moo.far.com", [appBoy getApiEndpoint:@"moo.far.com"]);
+//    XCTAssertEqualObjects(@"http://moo.far.com", [appBoy getApiEndpoint:@"http://moo.far.com"]);
+//}
 
 - (void)testSetMessageDelegate {
     id<ABKInAppMessageControllerDelegate> delegate = (id)[NSObject new];
@@ -275,6 +278,44 @@
     });
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testUserIdCustomerId {
+    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"ABKCollectIDFA":@"true",
+                                       @"userIdentificationType":@"CustomerId"
+                                       };
+
+    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    XCTAssertEqual(appBoy.userIdType, MPUserIdentityCustomerId);
+}
+
+- (void)testUserIdMPID {
+    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"ABKCollectIDFA":@"true",
+                                       @"userIdentificationType":@"MPID"
+                                       };
+
+    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    XCTAssertEqual(appBoy.userIdType, MPUserIdentityOther4);
 }
 
 @end


### PR DESCRIPTION
Walking through the code in my test app I confirmed that in the Braze Kit we are not checking what the External Identity Type is when setting the Braze User customer Id.