### PR TITLE
Use non-binary appboy dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk.json" ~> 3.20
+github "Appboy/appboy-ios-sdk" ~> 3.20
 github "mparticle/mparticle-apple-sdk" ~> 7.0


### PR DESCRIPTION
This is necessary because the version of the Appboy SDK specified by the manifest file does not include their UI libraries.