### PR TITLE
Start the kit early if Braze has been initialized

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+  pull_request: 
+
+jobs:
+  test:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set XCode Version
+      run: sudo xcode-select -s /Applications/Xcode_11.app
+    - name: Install Dependencies and test
+      run: |
+        pod repo update
+        pod lib lint
+      shell: bash

--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -222,16 +222,24 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     }
     
     _configuration = configuration;
-    if ([Appboy sharedInstance] ) {
-        _started = YES;
-    } else {
-        _started = NO;
-    }
+
     collectIDFA = NO;
     forwardScreenViews = NO;
     
     _host = configuration[hostConfigKey];
     _userIdType = [self userIdentityForString:configuration[userIdTypeKey]];
+    
+    //If Braze is already initialize, immediately "start" the kit, this
+    //is here for:
+    // 1. Apps that initialize Braze prior to mParticle, and/or
+    // 2. Apps that initialize mParticle too late, causing the SDK to miss
+    //    the launch notification which would otherwise trigger start().
+    if ([Appboy sharedInstance]) {
+        NSLog(@"mParticle -> Warning: Braze SDK initialized outside of mParticle kit, this will mean Braze settings within the mParticle dashboard such as API key, endpoint URL, flush interval and others will not be respected.");
+        [self start];
+    } else {
+        _started = NO;
+    }
     
     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;

--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -222,7 +222,11 @@ __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelega
     }
     
     _configuration = configuration;
-    _started = NO;
+    if ([Appboy sharedInstance] ) {
+        _started = YES;
+    } else {
+        _started = NO;
+    }
     collectIDFA = NO;
     forwardScreenViews = NO;
     


### PR DESCRIPTION
If the Braze kit has been initialized already, there's no reason to *not* mark it as started. This resolves an issue for customers who are late-initializing mParticle and Braze is missing the launch notification.