### PR TITLE
Allow Start to Set Flag on Reactivation

### DIFF
--- a/mParticle-Appboy/MPKitAppboy.m
+++ b/mParticle-Appboy/MPKitAppboy.m
@@ -300,16 +300,16 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
             self->appboyInstance.inAppMessageController.delegate = [MPKitAppboy inAppMessageControllerDelegate];
         }
 #endif
+    });
+    
+    self->_started = YES;
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
         
-        self->_started = YES;
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
-            
-            [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeActiveNotification
-                                                                object:nil
-                                                              userInfo:userInfo];
-        });
+        [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeActiveNotification
+                                                            object:nil
+                                                          userInfo:userInfo];
     });
 }
 


### PR DESCRIPTION
The '-Started' flag was not being set on 'start' after consent disables and then reenables a kit.  This was occurring because start was being done within a dispatch once which was only supposed to contain the setup for the kit sdk.