### PR TITLE
Update SPM SDK package to use braze url instead of AppBoy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
                url: "https://github.com/mParticle/mparticle-apple-sdk",
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Appboy_iOS_SDK",
-               url: "https://github.com/Appboy/appboy-ios-sdk",
+               url: "https://github.com/braze-inc/braze-ios-sdk",
                .upToNextMajor(from: "4.0.0")),
     ],
     targets: [


### PR DESCRIPTION
There have been some issues regarding the Appboy git URL cloning ~1.4GB of data when using the AppBoy link with SPM. 
More info:
https://github.com/Appboy/appboy-ios-sdk/issues/289
https://github.com/Appboy/appboy-segment-ios/pull/56

[Braze documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/swift_package_manager/?redirected=true#step-1-adding-the-dependency-to-your-project) also recommends using  https://github.com/braze-inc/braze-ios-sdk.