### PR TITLE
fix: prevent converting stringified zipcode to integer

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -650,6 +650,8 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
 #endif
     } else if ([key isEqualToString:mParticleUserAttributeMobileNumber] || [key isEqualToString:@"$MPUserMobile"]) {
         appboyInstance.user.phone = value;
+    } else if ([key isEqualToString:mParticleUserAttributeZip]){
+        [appboyInstance.user setCustomAttributeWithKey:@"Zip" andStringValue:value];
     } else {
         key = [self stripCharacter:@"$" fromString:key];
         


### PR DESCRIPTION
Summary
Food Truck Inc. has reported that when they use our reserved zipcode attribute it gets converted to a number/integer due to enabling the datatype detection in which is needed for other non-reserved attributes. This results in some zipcodes appearing wrong in some cases (for example: inputting "07090" as a zipcode would be forwarded to Braze as 7090).

Testing Plan
Tested the reserved zipcodes both if entered as a string value or a numeric value. Works fine on both where in the case of numeric values it would be stringified (in the case for some reason clients were passing reserved zipcode attribute as an integer).

Note: same issue relevant in Android and PR coming to the Appboy Android kit soon as well :)