### PR TITLE
fix: fix spm imports

### DIFF
--- a/Sources/mParticle-Appboy/include/mParticle_Appboy.h
+++ b/Sources/mParticle-Appboy/include/mParticle_Appboy.h
@@ -8,4 +8,8 @@ FOUNDATION_EXPORT const unsigned char mParticle_AppboyVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_Appboy/PublicHeader.h>
 
+#if defined(__has_include) && __has_include(<mParticle_Appboy/MPKitAppboy.h>)
 #import <mParticle_Appboy/MPKitAppboy.h>
+#else
+#import "MPKitAppboy.h"
+#endif


### PR DESCRIPTION
# Summary

While trying to import the package into one of their swift files a developer was getting the following error "Could not build objective-c module mParticle_Adobe".

Tested through targeting this branch with SPM in in swift example app.