### PR TITLE
Add SDK Metadata

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Appboy/appboy-ios-sdk" ~> 4.3.0
+github "Appboy/appboy-ios-sdk" ~> 4.4.0
 github "mparticle/mparticle-apple-sdk" ~> 8.0

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Appboy_iOS_SDK",
                url: "https://github.com/braze-inc/braze-ios-sdk",
-               .upToNextMajor(from: "4.0.0")),
+               .upToNextMajor(from: "4.4.0")),
     ],
     targets: [
         .target(

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -295,6 +295,8 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
     }
     CFTypeRef appboyRef = CFRetain((__bridge CFTypeRef)[Appboy sharedInstance]);
     self->appboyInstance = (__bridge Appboy *)appboyRef;
+
+    [self->appboyInstance addSdkMetadata:@[ABKSdkMetadataMParticle]];
     
     if (self->collectIDFA) {
         self->appboyInstance.idfaDelegate = (id)self;


### PR DESCRIPTION
# Summary

Starting with the Braze iOS SDK [4.4.0](https://github.com/Appboy/appboy-ios-sdk/blob/master/CHANGELOG.md#440), Braze can now track metadata about the integration method.

This PR marks mParticle integration with the appropriate SDK metadata, it also raises the minimum Braze iOS SDK to `4.4.0` to ensure that this feature is available.
