### PR TITLE
Fix that custom events with empty properties aren't logged

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -154,8 +154,13 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
         if (self->_enableTypeDetection) {
             detectedEventInfo = [self simplifiedDictionary:eventInfo];
         }
-        
-        [self->appboyInstance logCustomEvent:event.name withProperties:detectedEventInfo];
+
+        // Appboy expects that the properties are non empty when present.
+        if (detectedEventInfo && detectedEventInfo.count > 0) {
+            [self->appboyInstance logCustomEvent:event.name withProperties:detectedEventInfo];
+        } else {
+            [self->appboyInstance logCustomEvent:event.name];
+        }
         
         NSString *eventTypeString = [@(eventType) stringValue];
         

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -400,4 +400,29 @@
     [mockClient stopMocking];
 }
 
+- (void)testEventWithEmptyProperties {
+    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+
+    Appboy *testClient = [[Appboy alloc] init];
+    id mockClient = OCMPartialMock(testClient);
+    [kit setAppboyInstance:mockClient];
+
+    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
+
+
+    MPEvent *event = [[MPEvent alloc] initWithName:@"test event" type:MPEventTypeNavigation];
+    event.customAttributes = @{};
+
+    [kit setEnableTypeDetection:NO];
+    [[mockClient expect] logCustomEvent:event.name];
+
+    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
+
+    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
+
+    [mockClient verify];
+
+    [mockClient stopMocking];
+}
+
 @end


### PR DESCRIPTION
# Summary

`-[Appboy logCustomEvent:withProperties:]` doesn't track event when properties are an empty dictionary, because Appboy considers them as invalid.

This PR fixes this issue by calling `-[Appboy logCustomEvent:]` when the properties dictionary is empty.