### PR TITLE
Braze Configuration

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -59,6 +59,8 @@ static NSString *const userIdValueMPID = @"MPID";
 // User Attribute key with reserved functionality for Braze kit
 static NSString *const brazeUserAttributeDob = @"dob";
 
+static NSDictionary *_brazeOptions = nil;
+static BrazeConfigurationBlock brazeConfigurationBlock = nil;
 __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = nil;
 __weak static id<ABKURLDelegate> urlDelegate = nil;
 
@@ -83,6 +85,18 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
 + (void)load {
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"Appboy" className:@"MPKitAppboy"];
     [MParticle registerExtension:kitRegister];
+}
+
++ (NSDictionary *)brazeOptions {
+    return _brazeOptions;
+}
+
++ (void)setBrazeOptions:(NSDictionary *)brazeOptions {
+    _brazeOptions = brazeOptions;
+}
+
++ (void)configureBrazeInstanceWithBlock:(BrazeConfigurationBlock)configurationBlock {
+    brazeConfigurationBlock = configurationBlock;
 }
 
 + (void)setInAppMessageControllerDelegate:(id)delegate {
@@ -313,6 +327,11 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
     }
 #endif
     
+    if (brazeConfigurationBlock) {
+        brazeConfigurationBlock([self appboyInstance]);
+        brazeConfigurationBlock = nil;
+    }
+    
     self->_started = YES;
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -399,6 +418,11 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
     
     if ([MPKitAppboy urlDelegate]) {
         optionsDictionary[ABKURLDelegateKey] = (NSObject *)[MPKitAppboy urlDelegate];
+    }
+    
+    NSDictionary *brazeOptions = [[self class] brazeOptions];
+    if (brazeOptions) {
+        [optionsDictionary addEntriesFromDictionary:brazeOptions];
     }
     
     return optionsDictionary;

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -5,13 +5,23 @@
 #import "mParticle.h"
 #endif
 
+@class Appboy;
+
+typedef void(^BrazeConfigurationBlock)(Appboy *_Nonnull brazeInstance) NS_SWIFT_NAME(BrazeConfigurationHandler);
+
 @interface MPKitAppboy : NSObject <MPKitProtocol>
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 
-+ (void)setInAppMessageControllerDelegate:(nonnull id)delegate;
+@property (class, strong, nonatomic, nullable) NSDictionary *brazeOptions;
+
++ (void)configureBrazeInstanceWithBlock:(nonnull BrazeConfigurationBlock)configurationBlock
+    NS_SWIFT_NAME(configureBrazeInstance(configurationHandler:));
+
++ (void)setInAppMessageControllerDelegate:(nonnull id)delegate
+    DEPRECATED_MSG_ATTRIBUTE("Configure with a block instead");
 + (void)setURLDelegate:(nonnull id)delegate;
 
 @end


### PR DESCRIPTION
## Summary
* Added the `brazeOptions` property for passing additional configuration options to Braze at initialization time
* Added the `configureBrazeInstanceWithBlock:` method which allows for additional configuration of the Braze instance (e.g. setting delegates, etc.) once it’s initialized
* Deprecated the `setInAppMessageControllerDelegate:` method

## Testing Plan
* Tested manually in a production environment