### PR TITLE
fix: Add email_subscire and push_subscribe attribute fix

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -58,6 +58,8 @@ static NSString *const userIdValueMPID = @"MPID";
 
 // User Attribute key with reserved functionality for Braze kit
 static NSString *const brazeUserAttributeDob = @"dob";
+static NSString *const brazeUserAttributeEmailSubscribe = @"email_subscribe";
+static NSString *const brazeUserAttributePushSubscribe = @"push_subscribe";
 
 __weak static id<ABKInAppMessageControllerDelegate> inAppMessageControllerDelegate = nil;
 __weak static id<ABKURLDelegate> urlDelegate = nil;
@@ -659,6 +661,26 @@ __weak static id<ABKURLDelegate> urlDelegate = nil;
         appboyInstance.user.phone = value;
     } else if ([key isEqualToString:mParticleUserAttributeZip]){
         [appboyInstance.user setCustomAttributeWithKey:@"Zip" andStringValue:value];
+    } else if ([key isEqualToString:brazeUserAttributeEmailSubscribe]) {
+        if([value isEqualToString:@"opted_in"]) {
+            [appboyInstance.user setEmailNotificationSubscriptionType:ABKOptedIn];
+        } else if ([value isEqualToString:@"unsubscribed"]) {
+            [appboyInstance.user setEmailNotificationSubscriptionType:ABKUnsubscribed];
+        } else if ([value isEqualToString:@"subscribed"]) {
+            [appboyInstance.user setEmailNotificationSubscriptionType:ABKSubscribed];
+        } else {
+            NSLog(@"mParticle -> Invalid email_subscribe value: %@", value);
+        }
+    } else if ([key isEqualToString:brazeUserAttributePushSubscribe]) {
+        if([value isEqualToString:@"opted_in"]) {
+            [appboyInstance.user setPushNotificationSubscriptionType:ABKOptedIn];
+        } else if ([value isEqualToString:@"unsubscribed"]) {
+            [appboyInstance.user setPushNotificationSubscriptionType:ABKUnsubscribed];
+        } else if ([value isEqualToString:@"subscribed"]) {
+            [appboyInstance.user setPushNotificationSubscriptionType:ABKSubscribed];
+        } else {
+            NSLog(@"mParticle -> Invalid push_subscribe value: %@", value);
+        }
     } else {
         key = [self stripCharacter:@"$" fromString:key];
         


### PR DESCRIPTION
## Summary
A customer informed us that the email_subscribe and push_subscribe attribute assignment in Braze are not working per our [docs](https://docs.mparticle.com/integrations/braze/event/#user-attributes) stated. After further confirming and reproducing we also noticed that its the same case for the iOS integration as well and it was only working for the Web Braze kit.

## Testing Plan
Tested by changing the code in kit locally and applying the functions and sent the user attributes email_subscribe and push_subscribe with the values "opted_in", "subscribed" and "unsubscribed" and worked as expected by confirming in the Braze UI. Also, added logging when the value inputed is not one of the three values mentioned above and the error gets logged as expected