### PR TITLE
Fix: Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,8 @@ let package = Package(
             dependencies: [
               .byName(name: "mParticle-Apple-SDK"),
               .product(name: "BrazeUI", package: "braze-swift-sdk"),
+              .product(name: "BrazeKit", package: "braze-swift-sdk"),
+              .product(name: "BrazeKitCompat", package: "braze-swift-sdk"),
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             name: "mParticle-Appboy",
             dependencies: [
               .byName(name: "mParticle-Apple-SDK"),
-              .product(name: "AppboyUI", package: "Appboy_iOS_SDK"),
+              .product(name: "BrazeUI", package: "braze-swift-sdk"),
             ]
         )
     ]

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -2,12 +2,12 @@
 
 #if SWIFT_PACKAGE
     #ifdef TARGET_OS_IOS
-        import BrazeKit
-        import BrazeKitCompat
-        import BrazeUI
+        @import BrazeKit;
+        @import BrazeKitCompat;
+        @import BrazeUI;
     #else
-        import BrazeKit
-        import BrazeKitCompat
+        @import BrazeKit;
+        @import BrazeKitCompat;
     #endif
 #else
     #ifdef TARGET_OS_IOS


### PR DESCRIPTION
 ## Summary
Make `Package.swift` great again

Basically, the package is broken, and it can't be included in the project as dependencies can't resolve correctly. Another issues is that after that fix it is possible to include the package, but it doesn't compile because of errors inside of `braze-swift-sdk`

![Screenshot 2023-02-15 at 17 47 39](https://user-images.githubusercontent.com/722407/219078539-0179f55c-ab27-44f6-9b77-1bb12993cced.png)

 ## Testing Plan
 - [X] Was this tested locally?
 - Just try to add the latest version of the SDK into the test project
