### PR TITLE
Fix: In-app messages

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -52,7 +52,7 @@ static NSString *const userIdValueMPID = @"MPID";
 static NSString *const brazeUserAttributeDob = @"dob";
 
 #ifdef TARGET_OS_IOS
-__weak static id<BrazeInAppMessageUIDelegate> inAppMessageControllerDelegate = nil;
+static id<BrazeInAppMessagePresenter> inAppMessagePresenter = nil;
 #endif
 __weak static id<BrazeDelegate> urlDelegate = nil;
 
@@ -80,12 +80,10 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 }
 
 #ifdef TARGET_OS_IOS
-+ (void)setInAppMessageControllerDelegate:(id)delegate {
-    inAppMessageControllerDelegate = (id<BrazeInAppMessageUIDelegate>)delegate;
-}
-
-+ (id<BrazeInAppMessageUIDelegate>)inAppMessageControllerDelegate {
-    return inAppMessageControllerDelegate;
++ (void)setInAppMessagePresenter:(nonnull id)presenter {
+    if ([presenter conformsToProtocol:@protocol(BrazeInAppMessagePresenter)]) {
+        inAppMessagePresenter = presenter;
+    }
 }
 #endif
 
@@ -303,11 +301,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
     }
     
 #ifdef TARGET_OS_IOS
-    if ([MPKitAppboy inAppMessageControllerDelegate]) {
-        BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
-        inAppMessageUI.delegate = [MPKitAppboy inAppMessageControllerDelegate];
-        self->appboyInstance.inAppMessagePresenter = inAppMessageUI;
-    }
+    self->appboyInstance.inAppMessagePresenter = inAppMessagePresenter;
 #endif
     
     self->_started = YES;

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -306,6 +306,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
     if ([MPKitAppboy inAppMessageControllerDelegate]) {
         BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
         inAppMessageUI.delegate = [MPKitAppboy inAppMessageControllerDelegate];
+        self->appboyInstance.inAppMessagePresenter = inAppMessageUI;
     }
 #endif
     

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -11,7 +11,7 @@
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 
-+ (void)setInAppMessageControllerDelegate:(nonnull id)delegate;
++ (void)setInAppMessagePresenter:(nonnull id)presenter;
 + (void)setURLDelegate:(nonnull id)delegate;
 
 @end


### PR DESCRIPTION
 ## Summary
 - Allows setting in-app message presenter, as previously it didn't work. Such an approach supports custom implementations of a presenter.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with a default implementation settings it like this `MPKitAppboy.setInAppMessagePresenter(BrazeInAppMessageUI())`
