### PR TITLE
fix: Swift Package build errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,6 @@ let package = Package(
               .byName(name: "mParticle-Apple-SDK"),
               .product(name: "BrazeUI", package: "braze-swift-sdk"),
               .product(name: "BrazeKit", package: "braze-swift-sdk"),
-              .product(name: "BrazeKitCompat", package: "braze-swift-sdk"),
             ]
         )
     ]

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -3,20 +3,16 @@
 #if SWIFT_PACKAGE
     #ifdef TARGET_OS_IOS
         @import BrazeKit;
-        @import BrazeKitCompat;
         @import BrazeUI;
     #else
         @import BrazeKit;
-        @import BrazeKitCompat;
     #endif
 #else
     #ifdef TARGET_OS_IOS
         @import BrazeKit;
-        @import BrazeKitCompat;
         @import BrazeUI;
     #else
         @import BrazeKit;
-        @import BrazeKitCompat;
     #endif
 #endif
 


### PR DESCRIPTION
 ## Summary
👋  Dev from Reverb here! We're upgrading our integration to include the new Braze Swift SDK hoping it will resolve some issues we're experiencing, but we only use SPM for our dependencies. The swift package config was mostly fixed in #69, but the project isn't compiling due to errors in `BrazeKitCompat`. I read through your migration code to the Braze Swift SDK and noticed that y'all did a full migration, which disables the compatibility library. Since the migration is complete, we don't need to pull this package in at all. This should fix the build issues.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - I tested this locally in the Reverb project with success, but I'm getting "unsupported Swift architecture" when attempting to do the same with the test project. If someone can point me in the right direction, I'm happy to test this locally.
