### PR TITLE
fix: Crash when anonymous users return an NSNull email

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -781,7 +781,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             }
         }
         
-        if (userId) {
+        if (userId && ![userId isKindOfClass: [NSNull class]]) {
             void (^changeUser)(void) = ^ {
                 [self->appboyInstance changeUser:userId];
             };
@@ -849,7 +849,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             }
         }
         
-        if (userEmail) {
+        if (userEmail && ![userEmail isKindOfClass: [NSNull class]]) {
             [appboyInstance.user setEmail:userEmail];
             execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess];
         }


### PR DESCRIPTION
 ## Summary
Noticed this happening in `v8.1.1` after testing out #71.

NSNull user email was not being filtered by the **if (userEmail)** in `updateUser`. 

So `appboyInstance.user.setEmail` was being called with that NSNull object. But it expects an NSString, triggering an `unrecognized selector sent to instance` error.

<img width="1507" alt="null email" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/107946817/537c7486-b222-4648-ae71-dde342d8a320">


 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Only tested with a local app. I tried to create a new test but I wasn't able to instantiate an `MPKitConfiguration` for some reason.
