### PR TITLE
feat: add order level commerce events

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -432,7 +432,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             [properties addEntriesFromDictionary:baseProductAttributes];
         }
         
-        if (_configuration[bundleProductsWithCommerceEvents] && [_configuration[bundleProductsWithCommerceEvents] boolValue]) {
+        if ([_configuration[bundleProductsWithCommerceEvents] boolValue]) {
             NSArray *productArray = [self getProductListParameters:products];
             if (productArray.count > 0) {
                 [properties setValue:productArray forKey:productKey];
@@ -476,7 +476,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             }
         }
     } else {
-        if (_configuration[bundleProductsWithCommerceEvents] && [_configuration[bundleProductsWithCommerceEvents] boolValue]) {
+        if ([_configuration[bundleProductsWithCommerceEvents] boolValue]) {
             NSDictionary *transformedEventInfo = [commerceEvent.customAttributes transformValuesToString];
             
             NSMutableDictionary *eventInfo = [[NSMutableDictionary alloc] initWithCapacity:commerceEvent.customAttributes.count];
@@ -504,7 +504,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             
             NSString *eventName = [NSString stringWithFormat:@"eCommerce - %@", [self eventNameForAction:commerceEvent.action]];
             if ([eventName isEqualToString:@"eCommerce - unknown"]) {
-                if (commerceEvent.impressions != nil) {
+                if (commerceEvent.impressions) {
                     eventName = @"eCommerce - impression";
                 } else if (commerceEvent.promotionContainer.action) {
                     eventName = [NSString stringWithFormat:@"eCommerce - %@", [self eventNameForPromotionAction:commerceEvent.promotionContainer.action]];
@@ -512,7 +512,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             }
             
             // Appboy expects that the properties are non empty when present.
-            if (eventInfo && eventInfo.count > 0) {
+            if (eventInfo.count > 0) {
                 [self->appboyInstance logCustomEvent:eventName properties:eventInfo];
             } else {
                 [self->appboyInstance logCustomEvent:eventName];

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -432,7 +432,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             [properties addEntriesFromDictionary:baseProductAttributes];
         }
         
-        if (_configuration[forwardEnhancedCommerceDataKey]) {
+        if (_configuration[forwardEnhancedCommerceDataKey] && [_configuration[forwardEnhancedCommerceDataKey] boolValue]) {
             NSMutableArray *productArray;
             for (MPProduct *product in products) {
                 // Add attributes from the products themselves
@@ -475,7 +475,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
             }
         }
     } else {
-        if (_configuration[forwardEnhancedCommerceDataKey]) {
+        if (_configuration[forwardEnhancedCommerceDataKey] && [_configuration[forwardEnhancedCommerceDataKey] boolValue]) {
             NSDictionary *transformedEventInfo = [commerceEvent.customAttributes transformValuesToString];
             
             NSMutableDictionary *eventInfo = [[NSMutableDictionary alloc] initWithCapacity:commerceEvent.customAttributes.count];

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -1017,14 +1017,14 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 - (NSArray *)getPromotionListParameters:(NSArray<MPPromotion *> *)promotions {
     NSMutableArray *promotionArray = [[NSMutableArray alloc] init];
     for (MPPromotion *promotion in promotions) {
-        // Add attributes from the products themselves
+        // Add attributes from the promotions themselves
         NSMutableDictionary *promotionDictionary = [[NSMutableDictionary alloc] init];
         promotionDictionary[@"Creative"] = promotion.creative;
         promotionDictionary[@"Name"] = promotion.name;
         promotionDictionary[@"Position"] = promotion.position;
         promotionDictionary[@"Id"] = promotion.promotionId;
                         
-        // Adds the product dictionary to the product array being supplied to Braze
+        // Adds the promotion dictionary to the promotion array being supplied to Braze
         [promotionArray addObject:promotionDictionary];
     }
     return promotionArray;
@@ -1039,7 +1039,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
         NSArray<MPProduct *> *impressionProducts = [[impressions[impressionName] allObjects] copy];
         impressionDictionary[productKey] = [self getProductListParameters:impressionProducts];
 
-        // Adds the product dictionary to the product array being supplied to Braze
+        // Adds the impression dictionary to the impression array being supplied to Braze
         [impressionArray addObject:impressionDictionary];
     }
     return impressionArray;

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Appboy"
-    s.version          = "8.1.1"
+    s.version          = "8.2.0"
     s.summary          = "Appboy integration for mParticle"
 
     s.description      = <<-DESC

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Appboy"
-    s.version          = "8.2.0"
+    s.version          = "8.1.1"
     s.summary          = "Appboy integration for mParticle"
 
     s.description      = <<-DESC

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -377,7 +377,7 @@
     event.transactionAttributes = attributes;
 
     [[mockClient expect] logCustomEvent:@"eCommerce - click"
-                          properties:@{@"testKey" : @"testCustomAttValue",
+                          properties:@{@"Attributes" : @{@"testKey" : @"testCustomAttValue"},
                                        @"products" : @[@{
                                            @"Id" : @"1131331343",
                                            @"Item Price" : @"13",
@@ -410,6 +410,8 @@
     MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
 
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
+    event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
+
     MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
     attributes.transactionId = @"foo-transaction-id";
     attributes.revenue = @13.00;
@@ -452,6 +454,8 @@
     MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
 
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
+    event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
+
     MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
     attributes.transactionId = @"foo-transaction-id";
     attributes.revenue = @13.00;
@@ -460,7 +464,8 @@
 
     event.transactionAttributes = attributes;
 
-    NSDictionary *testResultDict = @{@"Shipping Amount" : @3,
+    NSDictionary *testResultDict = @{@"Attributes" : @{@"testKey" : @"testCustomAttValue"},
+                                     @"Shipping Amount" : @3,
                                      @"Total Amount" : @13.00,
                                      @"Tax Amount" : @3,
                                      @"Transaction Id" : @"foo-transaction-id",
@@ -530,6 +535,8 @@
 
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase];
     [event addProducts:@[product1, product2]];
+    event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
+
     MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
     attributes.transactionId = @"foo-transaction-id";
     attributes.revenue = @26.00;
@@ -538,7 +545,8 @@
 
     event.transactionAttributes = attributes;
 
-    NSDictionary *testResultDict = @{@"Shipping Amount" : @3,
+    NSDictionary *testResultDict = @{@"Attributes" : @{@"testKey" : @"testCustomAttValue"},
+                                     @"Shipping Amount" : @3,
                                      @"Total Amount" : @26.00,
                                      @"Tax Amount" : @3,
                                      @"Transaction Id" : @"foo-transaction-id",
@@ -555,7 +563,7 @@
                                                          @"Name" : @"product2",
                                                          @"Quantity" : @"1",
                                                          @"Total Product Amount" : @"13",
-                                                         @"testKey" : @"testCustomAttValue"
+                                                         @"Attributes" : @{@"testKey" : @"testCustomAttValue"}
                                                      }
                                      ]
     };
@@ -624,7 +632,7 @@
     event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
 
     [[mockClient expect] logCustomEvent:@"eCommerce - view"
-                          properties:@{@"testKey" : @"testCustomAttValue",
+                          properties:@{@"Attributes" : @{@"testKey" : @"testCustomAttValue"},
                                        @"promotions" : @[@{
                                            @"Creative" : @"sale_banner_1",
                                            @"Name" : @"App-wide 50% off sale",
@@ -655,12 +663,13 @@
     XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
 
     MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+    product.userDefinedAttributes = [@{@"productTestKey" : @"productTestCustomAttValue"} mutableCopy];
 
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithImpressionName:@"Suggested Products List" product:product];
     event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
 
     [[mockClient expect] logCustomEvent:@"eCommerce - impression"
-                          properties:@{@"testKey" : @"testCustomAttValue",
+                          properties:@{@"Attributes" : @{@"testKey" : @"testCustomAttValue"},
                                        @"impressions" : @[@{
                                            @"Product Impression List" : @"Suggested Products List",
                                            @"products" : @[@{
@@ -668,7 +677,8 @@
                                                @"Item Price" : @"13",
                                                @"Name" : @"product1",
                                                @"Quantity" : @"1",
-                                               @"Total Product Amount" : @"13"
+                                               @"Total Product Amount" : @"13",
+                                               @"Attributes" : @{@"productTestKey" : @"productTestCustomAttValue"}
                                               }
                                            ]
                                           }

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -311,47 +311,294 @@
     XCTAssertEqual(appBoy.configuration[@"userIdentificationType"], @"MPID");
 }
 
-//- (void)testlogCommerceEvent {
-//    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
-//
-//    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-//    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-//    id mockClient = OCMPartialMock(testClient);
-//    [kit setAppboyInstance:mockClient];
-//
-//    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
-//
-//    MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
-//
-//    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
-//    MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
-//    attributes.transactionId = @"foo-transaction-id";
-//    attributes.revenue = @13.00;
-//    attributes.tax = @3;
-//    attributes.shipping = @-3;
-//
-//    event.transactionAttributes = attributes;
-//
-//    [[mockClient expect] logPurchase:@"1131331343"
-//                          inCurrency:@"USD"
-//                             atPrice:[[NSDecimalNumber alloc] initWithString:@"13"]
-//                        withQuantity:[[NSNumber numberWithInteger:1] longLongValue]
-//                       andProperties:@{@"Shipping Amount" : @-3,
-//                                       @"Total Amount" : @13.00,
-//                                       @"Total Product Amount" : @"13",
-//                                       @"Tax Amount" : @3,
-//                                       @"Transaction Id" : @"foo-transaction-id"
-//                       }];
-//
-//    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
-//
-//    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
-//
-//    [mockClient verify];
-//
-//    [mockClient stopMocking];
-//}
-//
+- (void)testlogCommerceEvent {
+    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    id mockClient = OCMPartialMock(testClient);
+    [kit setAppboyInstance:mockClient];
+
+    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
+
+    MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionClick product:product];
+    event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
+    
+    MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
+    attributes.transactionId = @"foo-transaction-id";
+    attributes.revenue = @13.00;
+    attributes.tax = @3;
+    attributes.shipping = @-3;
+
+    event.transactionAttributes = attributes;
+
+    [[mockClient expect] logCustomEvent:@"eCommerce - click - Item"
+                          properties:@{@"Id" : @"1131331343",
+                                       @"Item Price" : @"13",
+                                       @"Name" : @"product1",
+                                       @"Quantity" : @"1",
+                                       @"Total Product Amount" : @"13",
+                                       @"testKey" : @"testCustomAttValue"
+                       }];
+
+    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
+
+    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
+
+    [mockClient verify];
+
+    [mockClient stopMocking];
+}
+
+- (void)testlogCommerceEventWithBundledProducts {
+    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+    kit.configuration = @{@"bundleProductsWithCommerceEvents" : @1};
+
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    id mockClient = OCMPartialMock(testClient);
+    [kit setAppboyInstance:mockClient];
+
+    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
+
+    MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionClick product:product];
+    event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
+
+    MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
+    attributes.transactionId = @"foo-transaction-id";
+    attributes.revenue = @13.00;
+    attributes.tax = @3;
+    attributes.shipping = @-3;
+
+    event.transactionAttributes = attributes;
+
+    [[mockClient expect] logCustomEvent:@"eCommerce - click"
+                          properties:@{@"testKey" : @"testCustomAttValue",
+                                       @"products" : @[@{
+                                           @"Id" : @"1131331343",
+                                           @"Item Price" : @"13",
+                                           @"Name" : @"product1",
+                                           @"Quantity" : @"1",
+                                           @"Total Product Amount" : @"13"
+                                          }
+                                       ]
+                       }];
+
+    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
+
+    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
+
+    [mockClient verify];
+
+    [mockClient stopMocking];
+}
+
+- (void)testlogPurchaseCommerceEvent {
+    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    id mockClient = OCMPartialMock(testClient);
+    [kit setAppboyInstance:mockClient];
+
+    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
+
+    MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
+    MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
+    attributes.transactionId = @"foo-transaction-id";
+    attributes.revenue = @13.00;
+    attributes.tax = @3;
+    attributes.shipping = @-3;
+
+    event.transactionAttributes = attributes;
+
+    [[mockClient expect] logPurchase:@"1131331343"
+                            currency:@"USD"
+                               price:[@"13" doubleValue]
+                            quantity:1
+                          properties:@{@"Shipping Amount" : @-3,
+                                       @"Total Amount" : @13.00,
+                                       @"Total Product Amount" : @"13",
+                                       @"Tax Amount" : @3,
+                                       @"Transaction Id" : @"foo-transaction-id"
+                       }];
+
+    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
+
+    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
+
+    [mockClient verify];
+
+    [mockClient stopMocking];
+}
+
+- (void)testlogPurchaseCommerceEventWithBundledProducts {
+    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+    kit.configuration = @{@"bundleProductsWithCommerceEvents" : @1};
+
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    id mockClient = OCMPartialMock(testClient);
+    [kit setAppboyInstance:mockClient];
+
+    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
+
+    MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
+    MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
+    attributes.transactionId = @"foo-transaction-id";
+    attributes.revenue = @13.00;
+    attributes.tax = @3;
+    attributes.shipping = @-3;
+
+    event.transactionAttributes = attributes;
+
+    NSDictionary *testResultDict = @{@"Shipping Amount" : @-3,
+                                     @"Total Amount" : @13.00,
+                                     @"Tax Amount" : @3,
+                                     @"Transaction Id" : @"foo-transaction-id",
+                                     @"products" : @[@{
+                                         @"Id" : @"1131331343",
+                                         @"Item Price" : @"13",
+                                         @"Name" : @"product1",
+                                         @"Quantity" : @"1",
+                                         @"Total Product Amount" : @"13"
+                                        }
+                                     ]
+    };
+    BOOL (^testBlock)(id value) = ^BOOL(id value) {
+        if ([value isKindOfClass:[NSDictionary class]]) {
+            for (NSString *key in [(NSDictionary *)value allKeys]) {
+                if ([key isEqualToString: @"products"]) {
+                    NSArray *productArray = (NSArray *)((NSDictionary *)value[key]);
+                    for (int i = 0; i < productArray.count; i++) {
+                        NSDictionary *productDict = productArray[i];
+                        for (NSString *productDictKey in [productDict allKeys]) {
+                            if (![productDict[productDictKey] isEqual:testResultDict[key][i][productDictKey]]) {
+                                NSLog(@"Invalid Object in Product: %@ Key: %@", productDict, productDictKey);
+                                return false;
+                            }
+                        }
+                    }
+                }
+                if (![(NSDictionary *)value[key] isEqual:testResultDict[key]]) {
+                    NSLog(@"Invalid Object in Key: %@", key);
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    };
+    
+    OCMExpect(([mockClient logPurchase:@"eCommerce - purchase"
+                              currency:@"USD"
+                                 price:[@"13" doubleValue]
+                            properties:[OCMArg checkWithBlock:testBlock]
+               ]));
+              
+    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
+
+    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
+
+    OCMVerifyAll(mockClient);
+
+    [mockClient stopMocking];
+}
+
+- (void)testlogCommerceEventWithMultipleBundledProducts {
+    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+    kit.configuration = @{@"bundleProductsWithCommerceEvents" : @1};
+
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    id mockClient = OCMPartialMock(testClient);
+    [kit setAppboyInstance:mockClient];
+
+    XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
+
+    MPProduct *product1 = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+    MPProduct *product2 = [[MPProduct alloc] initWithName:@"product2" sku:@"1131331888" quantity:@1 price:@13];
+    product2.userDefinedAttributes[@"testKey"] = @"testCustomAttValue";
+
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase];
+    [event addProducts:@[product1, product2]];
+    MPTransactionAttributes *attributes = [[MPTransactionAttributes alloc] init];
+    attributes.transactionId = @"foo-transaction-id";
+    attributes.revenue = @26.00;
+    attributes.tax = @3;
+    attributes.shipping = @-3;
+
+    event.transactionAttributes = attributes;
+
+    NSDictionary *testResultDict = @{@"Shipping Amount" : @-3,
+                                     @"Total Amount" : @26.00,
+                                     @"Tax Amount" : @3,
+                                     @"Transaction Id" : @"foo-transaction-id",
+                                     @"products" : @[@{
+                                                         @"Id" : @"1131331343",
+                                                         @"Item Price" : @"13",
+                                                         @"Name" : @"product1",
+                                                         @"Quantity" : @"1",
+                                                         @"Total Product Amount" : @"13"
+                                                    },
+                                                     @{
+                                                         @"Id" : @"1131331888",
+                                                         @"Item Price" : @"13",
+                                                         @"Name" : @"product2",
+                                                         @"Quantity" : @"1",
+                                                         @"Total Product Amount" : @"13",
+                                                         @"testKey" : @"testCustomAttValue"
+                                                     }
+                                     ]
+    };
+    BOOL (^testBlock)(id value) = ^BOOL(id value) {
+        if ([value isKindOfClass:[NSDictionary class]]) {
+            for (NSString *key in [(NSDictionary *)value allKeys]) {
+                if ([key isEqualToString: @"products"]) {
+                    NSArray *productArray = (NSArray *)((NSDictionary *)value[key]);
+                    for (int i = 0; i < productArray.count; i++) {
+                        NSDictionary *productDict = productArray[i];
+                        for (NSString *productDictKey in [productDict allKeys]) {
+                            if (![productDict[productDictKey] isEqual:testResultDict[key][i][productDictKey]]) {
+                                NSLog(@"Invalid Object in Product: %@ Key: %@", productDict, productDictKey);
+                                return false;
+                            }
+                        }
+                    }
+                }
+                if (![(NSDictionary *)value[key] isEqual:testResultDict[key]]) {
+                    NSLog(@"Invalid Object in Key: %@", key);
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    };
+    
+    OCMExpect(([mockClient logPurchase:@"eCommerce - purchase"
+                              currency:@"USD"
+                                 price:[@"26" doubleValue]
+                            properties:[OCMArg checkWithBlock:testBlock]
+               ]));
+              
+    MPKitExecStatus *execStatus = [kit logBaseEvent:event];
+
+    XCTAssertEqual(execStatus.returnCode, MPKitReturnCodeSuccess);
+
+    OCMVerifyAll(mockClient);
+
+    [mockClient stopMocking];
+}
+
 //- (void)testTypeDetection {
 //    MPKitAppboy *kit = [[MPKitAppboy alloc] init];
 //


### PR DESCRIPTION
## Summary
1. All commerce events (both purchase and non-purchase events) forwarded to Braze as a single event with products nested in event properties when forwardEnhancedECommerceData set to true.
2. All commerce events (both purchase and non-purchase events) forwarded to Braze as expanded individual events for each product when forwardEnhancedECommerceData set to false.

 ## Testing Plan
 - Tested manualy

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5427
