### PR TITLE
feat: Add NoLocation target to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,10 @@ let package = Package(
         .library(
             name: "mParticle-Appboy",
             targets: ["mParticle-Appboy"]),
+        .library(
+            name: "mParticle-Appboy-NoLocation",
+            targets: ["mParticle-Appboy-NoLocation"]
+        )
     ],
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
@@ -23,11 +27,21 @@ let package = Package(
         .target(
             name: "mParticle-Appboy",
             dependencies: [
-              .byName(name: "mParticle-Apple-SDK"),
+              .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
               .product(name: "BrazeUI", package: "braze-swift-sdk", condition: .when(platforms: [.iOS])),
               .product(name: "BrazeKit", package: "braze-swift-sdk"),
               .product(name: "BrazeKitCompat", package: "braze-swift-sdk"),
             ]
+        ),
+        .target(
+            name: "mParticle-Appboy-NoLocation",
+            dependencies: [
+              .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
+              .product(name: "BrazeUI", package: "braze-swift-sdk", condition: .when(platforms: [.iOS])),
+              .product(name: "BrazeKit", package: "braze-swift-sdk"),
+              .product(name: "BrazeKitCompat", package: "braze-swift-sdk"),
+            ],
+            path: "SPM/mParticle-Appboy-NoLocation"
         )
     ]
 )

--- a/SPM/mParticle-Appboy-NoLocation
+++ b/SPM/mParticle-Appboy-NoLocation
@@ -1,0 +1,1 @@
+../Sources/mParticle-Appboy

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
 #endif
 
 @interface MPKitAppboy : NSObject <MPKitProtocol>

--- a/Sources/mParticle-Appboy/include/mParticle_Appboy.h
+++ b/Sources/mParticle-Appboy/include/mParticle_Appboy.h
@@ -9,7 +9,9 @@ FOUNDATION_EXPORT const unsigned char mParticle_AppboyVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_Appboy/PublicHeader.h>
 
 #if defined(__has_include) && __has_include(<mParticle_Appboy/MPKitAppboy.h>)
-#import <mParticle_Appboy/MPKitAppboy.h>
+    #import <mParticle_Appboy/MPKitAppboy.h>
+#elif defined(__has_include) && __has_include(<mParticle_Appboy_NoLocation/MPKitAppboy.h>)
+    #import <mParticle_Appboy_NoLocation/MPKitAppboy.h>
 #else
-#import "MPKitAppboy.h"
+    #import "MPKitAppboy.h"
 #endif


### PR DESCRIPTION
 ## Summary
Add dedicated NoLocation target to SPM with a dependency on the NoLocation version of the mParticle SDK. This prevents the issue where a customer adds the NoLocation SDK and then the kit depends on the standard version, which causes both to be included.

 ## Testing Plan
- Confirmed in a test app that both targets work as expected

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5439
