### PR TITLE
fix: in app message display fix for new Braze swift kit

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -299,10 +299,9 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
     }
     
 #if TARGET_OS_IOS
-    if ([MPKitAppboy inAppMessageControllerDelegate]) {
-        BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
-        inAppMessageUI.delegate = [MPKitAppboy inAppMessageControllerDelegate];
-    }
+    BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
+    inAppMessageUI.delegate = [MPKitAppboy inAppMessageControllerDelegate];
+    [self->appboyInstance setInAppMessagePresenter:inAppMessageUI];
 #endif
     
     self->_started = YES;


### PR DESCRIPTION
 ## Summary
 - multiple customers have mentioned that Braze in app messages stopped working since version 8.1.0 when we started utilizing the newer Braze swift SDK, after further investigation it seems that we were missing the line to include the inAppMessagePresenter.

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Tested locally with firing a dummy inAppMessage from Braze to my iOS simulator

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-5617
