### PR TITLE
fix:Correct Push Notifications for Notification Center

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -564,7 +564,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 
 #if TARGET_OS_IOS
     if (![appboyInstance.notifications handleBackgroundNotificationWithUserInfo:userInfo fetchCompletionHandler:^(UIBackgroundFetchResult fetchResult) {}]) {
-        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeFail];
+        NSLog(@"mParticle -> Invalid Braze remote notification: %@", userInfo);
     }
 #endif
     
@@ -933,11 +933,21 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 }
 
 #if TARGET_OS_IOS
+- (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center willPresentNotification:(nonnull UNNotification *)notification {
+    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess];
+
+    if (![appboyInstance.notifications handleBackgroundNotificationWithUserInfo:notification.request.content.userInfo fetchCompletionHandler:^(UIBackgroundFetchResult fetchResult) {}]) {
+        NSLog(@"mParticle -> Invalid Braze remote notification: %@", notification.request.content.userInfo);
+    }
+    
+    return execStatus;
+}
+
 - (nonnull MPKitExecStatus *)userNotificationCenter:(nonnull UNUserNotificationCenter *)center didReceiveNotificationResponse:(nonnull UNNotificationResponse *)response API_AVAILABLE(ios(10.0)) {
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess];
 
     if (![appboyInstance.notifications handleUserNotificationWithResponse:response withCompletionHandler:^{}]) {
-        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeFail];
+        NSLog(@"mParticle -> Notification Response rejected by Braze: %@", response);
     }
     
     return execStatus;


### PR DESCRIPTION
## Summary
 - While testing a fix for the apple sdk around forward record counts for push messages,  I realized these were being sent to braze for the old push message method (didReceiveRemoteNotification on appDelegate) but not for the userNotificationCenter way. It was only recording responses, this corrects that issue

 ## Testing Plan
 - confirmed with local testing and mparticle UI
<img width="255" alt="Screenshot 2023-09-27 at 12 26 08 PM" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/33703490/dde0b884-9d7d-4324-be49-a414a0043593">

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5624
