### PR TITLE
BrazeLocationProvider added to make automatic location collection works

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -4,6 +4,7 @@
     @import BrazeKit;
     @import BrazeKitCompat;
     @import BrazeUI;
+    @import BrazeLocation;
 #else
     @import BrazeKit;
     @import BrazeKitCompat;
@@ -282,7 +283,10 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
         configuration.api.flushInterval = ((NSNumber *)optionsDict[ABKFlushIntervalOptionKey]).doubleValue;
         configuration.sessionTimeout = ((NSNumber *)optionsDict[ABKSessionTimeoutKey]).doubleValue;
         configuration.triggerMinimumTimeInterval = ((NSNumber *)optionsDict[ABKMinimumTriggerTimeIntervalKey]).doubleValue;
-        configuration.location.automaticLocationCollection = optionsDict[ABKEnableAutomaticLocationCollectionKey];
+        configuration.location.automaticLocationCollection = ((NSNumber *)optionsDict[ABKEnableAutomaticLocationCollectionKey]).boolValue;
+        if (configuration.location.automaticLocationCollection) {
+            configuration.location.brazeLocationProvider = [[BrazeLocationProvider alloc] init];
+        }
         [configuration.api addSDKMetadata:@[BRZSDKMetadata.mparticle]];
         configuration.api.sdkFlavor = ((NSNumber *)optionsDict[ABKSDKFlavorKey]).intValue;
         


### PR DESCRIPTION
…ection works on Braze

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
What I did is reading the Braze Docs and I realized that the Automatic Location Collection was disabled because we were not  providing a BrazeLocationProvider so it was set to null 
![image](https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/33323953/9a9ce76b-2ef0-40b0
<img width="580" alt="withoutBrazeProvider" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/33323953/5574ba9d-29db-46e9-a7d2-4e5688ea59f0">
-90c2-13c34a04df43)
So the location was not being collected on the Braze side

<img width="1481" alt="userwithoutBrazeProvider" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/33323953/6e073cec-c1f1-4974-b1f3-9e5c06cea2a3">

Then I added the configuration that was needed:
```
        if (configuration.location.automaticLocationCollection) {
            configuration.location.brazeLocationProvider = [[BrazeLocationProvider alloc] init];
        }
```
And it started working correctly
<img width="574" alt="withBrazeProvider" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/33323953/686f321a-de57-4b74-a65c-2901840bf16b">
<img width="1478" alt="userwithBrazeProvider" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/33323953/7e055201-0c49-4d14-9aef-6df970199ada">



 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
