### PR TITLE
Fix: bundle commerce event setting

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -405,10 +405,6 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 - (MPKitExecStatus *)routeCommerceEvent:(MPCommerceEvent *)commerceEvent {
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess forwardCount:0];
     
-    NSMutableDictionary *mutDict = [_configuration mutableCopy];
-    mutDict[bundleCommerceEventData] = @true;
-    _configuration = mutDict;
-    
     if (commerceEvent.action == MPCommerceEventActionPurchase) {
         NSMutableDictionary *baseProductAttributes = [[NSMutableDictionary alloc] init];
         NSDictionary *transactionAttributes = [self simplifiedDictionary:[commerceEvent.transactionAttributes beautifiedDictionaryRepresentation]];

--- a/mParticle-Appboy.xcodeproj/project.pbxproj
+++ b/mParticle-Appboy.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -727,7 +727,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Appboy";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
 			};
 			name = Debug;
 		};
@@ -745,7 +744,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Appboy";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
 			};
 			name = Release;
 		};
@@ -787,8 +785,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=appletvsimulator*]" = x86_64;
 			};
 			name = Debug;
 		};
@@ -830,8 +826,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=appletvsimulator*]" = x86_64;
 			};
 			name = Release;
 		};

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -313,6 +313,7 @@
 
 - (void)testlogCommerceEvent {
     MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+    kit.configuration = @{@"bundleCommerceEventData" : @0};
 
     BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
     Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
@@ -399,6 +400,7 @@
 
 - (void)testlogPurchaseCommerceEvent {
     MPKitAppboy *kit = [[MPKitAppboy alloc] init];
+    kit.configuration = @{@"bundleCommerceEventData" : @0};
 
     BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
     Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];


### PR DESCRIPTION
 ## Summary
 - This PR Fixes the bundleCommerceEventData config that was placed in the function that send the data to Braze, which override the current setting for the connection that can be seen in the UI.
 - Test for unbundled data are also fixed by setting the bundleCommerceEventData config explicitly to false on.
 - VALID_ARCHS setting within the project is modified to avoid a build issue for M1+ Macs.
 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Test performed manually in addition to fixing the unit tests. Previously, only bundled data could be seen in Braze's dashboard. Now the config via mParticle UI is taken into account.
 Unbundled data in Braze:
 
<img width="559" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/d1bb3fbb-4de7-474b-a034-7fdb15718a50">

<img width="500" alt="unbundled" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/21b01efd-f587-40cc-b46f-ea16a5a51916">

Bundled data in Braze:

<img width="558" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/449c4d98-8acd-43e7-a063-586a67e4bb4c">

<img width="493" alt="bundled" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/9b35ba56-614d-4a64-b23c-e802d2174cc2">


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-5916
