### PR TITLE
fix: Deleting property stripping from product when sent unbundled

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -467,7 +467,7 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
                 }
                 
                 // Strips key/values already being passed to Appboy, plus key/values initialized to default values
-                keys = @[kMPExpProductSKU, kMPProductCurrency, kMPExpProductUnitPrice, kMPExpProductQuantity, kMPProductAffiliation, kMPExpProductCategory, kMPExpProductName];
+                keys = @[kMPExpProductSKU, kMPProductCurrency, kMPExpProductUnitPrice, kMPExpProductQuantity];
                 [properties removeObjectsForKeys:keys];
                 
                 [appboyInstance logPurchase:product.sku

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -410,6 +410,7 @@
     XCTAssertEqualObjects(mockClient, [kit appboyInstance]);
 
     MPProduct *product = [[MPProduct alloc] initWithName:@"product1" sku:@"1131331343" quantity:@1 price:@13];
+    product.category = @"category1";
 
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
     event.customAttributes = @{@"testKey" : @"testCustomAttValue"};
@@ -431,7 +432,8 @@
                                        @"Total Product Amount" : @"13",
                                        @"Tax Amount" : @3,
                                        @"Transaction Id" : @"foo-transaction-id",
-                                       @"Name" : @"product1"
+                                       @"Name" : @"product1",
+                                       @"Category" : @"category1"
                        }];
 
     MPKitExecStatus *execStatus = [kit logBaseEvent:event];

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -430,7 +430,8 @@
                                        @"Total Amount" : @13.00,
                                        @"Total Product Amount" : @"13",
                                        @"Tax Amount" : @3,
-                                       @"Transaction Id" : @"foo-transaction-id"
+                                       @"Transaction Id" : @"foo-transaction-id",
+                                       @"Name" : @"product1"
                        }];
 
     MPKitExecStatus *execStatus = [kit logBaseEvent:event];


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR allows sending the product name, category and affiliation when sending each product separately for a purchase event. I've modified the associated test as well.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
It was tested manually by checking the payloads that braze receives.

This is a sample payload of a product with category without the change:
<img width="490" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/d8a19ebc-0a59-4945-bfcb-98ba80f2133d">

This is a sample payload with the change:
<img width="486" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/f3d2c7e8-8c1d-4b30-9e9f-67533f9dd975">


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)

