### PR TITLE
feat: Allow setting Braze instance and override notification handling

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -52,6 +52,7 @@ __weak static id<BrazeInAppMessageUIDelegate> inAppMessageControllerDelegate = n
 static BOOL shouldDisableNotificationHandling = NO;
 #endif
 __weak static id<BrazeDelegate> urlDelegate = nil;
+static Braze *brazeInstance = nil;
 
 @interface MPKitAppboy() {
     Braze *appboyInstance;
@@ -101,6 +102,14 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 
 + (id<BrazeDelegate>)urlDelegate {
     return urlDelegate;
+}
+
++ (void)setBrazeInstance:(Braze *)instance {
+    brazeInstance = instance;
+}
+
++ (Braze *)brazeInstance {
+    return brazeInstance;
 }
 
 #pragma mark Private methods
@@ -249,6 +258,10 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
 
 #pragma mark MPKitInstanceProtocol methods
 - (MPKitExecStatus *)didFinishLaunchingWithConfiguration:(NSDictionary *)configuration {
+    
+    // Use the static braze instance if set
+    [self setAppboyInstance:brazeInstance];
+    
     MPKitExecStatus *execStatus = nil;
     
     if (!configuration[eabAPIKey]) {
@@ -275,6 +288,8 @@ __weak static id<BrazeDelegate> urlDelegate = nil;
     } else {
         _started = NO;
     }
+    
+   
     
     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -104,8 +104,10 @@ static Braze *brazeInstance = nil;
     return urlDelegate;
 }
 
-+ (void)setBrazeInstance:(Braze *)instance {
-    brazeInstance = instance;
++ (void)setBrazeInstance:(id)instance {
+    if ([instance isKindOfClass:[Braze class]]) {
+        brazeInstance = instance;
+    }
 }
 
 + (Braze *)brazeInstance {

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -18,6 +18,7 @@
 
 #if TARGET_OS_IOS
 + (void)setInAppMessageControllerDelegate:(nonnull id)delegate;
++ (void)setShouldDisableNotificationHandling:(BOOL)isDisabled;
 #endif
 + (void)setURLDelegate:(nonnull id)delegate;
 

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -10,7 +10,6 @@
     #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
-@class Braze;
 @interface MPKitAppboy : NSObject <MPKitProtocol>
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
@@ -22,6 +21,6 @@
 + (void)setShouldDisableNotificationHandling:(BOOL)isDisabled;
 #endif
 + (void)setURLDelegate:(nonnull id)delegate;
-+ (void)setBrazeInstance:(nonnull Braze *)instance;
++ (void)setBrazeInstance:(nonnull id)instance;
 
 @end

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -10,6 +10,7 @@
     #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
+@class Braze;
 @interface MPKitAppboy : NSObject <MPKitProtocol>
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
@@ -21,5 +22,6 @@
 + (void)setShouldDisableNotificationHandling:(BOOL)isDisabled;
 #endif
 + (void)setURLDelegate:(nonnull id)delegate;
++ (void)setBrazeInstance:(nonnull Braze *)instance;
 
 @end

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -16,6 +16,7 @@
 - (NSMutableDictionary<NSString *, NSNumber *> *)optionsDictionary;
 + (id<BrazeInAppMessageUIDelegate>)inAppMessageControllerDelegate;
 - (void)setEnableTypeDetection:(BOOL)enableTypeDetection;
++ (BOOL)shouldDisableNotificationHandling;
 
 @end
 
@@ -273,6 +274,18 @@
     });
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testSetDisableNotificationHandling {
+    XCTAssertEqual([MPKitAppboy shouldDisableNotificationHandling], NO);
+    
+    [MPKitAppboy setShouldDisableNotificationHandling:YES];
+    
+    XCTAssertEqual([MPKitAppboy shouldDisableNotificationHandling], YES);
+    
+    [MPKitAppboy setShouldDisableNotificationHandling:NO];
+    
+    XCTAssertEqual([MPKitAppboy shouldDisableNotificationHandling], NO);
 }
 
 - (void)testUserIdCustomerId {

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -17,6 +17,7 @@
 + (id<BrazeInAppMessageUIDelegate>)inAppMessageControllerDelegate;
 - (void)setEnableTypeDetection:(BOOL)enableTypeDetection;
 + (BOOL)shouldDisableNotificationHandling;
++ (Braze *)brazeInstance;
 
 @end
 
@@ -29,6 +30,7 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
+    [MPKitAppboy setBrazeInstance:nil];
 }
 
 - (void)tearDown {
@@ -286,6 +288,37 @@
     [MPKitAppboy setShouldDisableNotificationHandling:NO];
     
     XCTAssertEqual([MPKitAppboy shouldDisableNotificationHandling], NO);
+}
+
+- (void)testSetBrazeInstance {
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    
+    XCTAssertEqualObjects([MPKitAppboy brazeInstance], nil);
+
+    [MPKitAppboy setBrazeInstance:testClient];
+    
+    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];
+    
+    XCTAssertEqualObjects(appBoy.appboyInstance, nil);
+    XCTAssertEqualObjects(appBoy.providerKitInstance, nil);
+    XCTAssertEqualObjects([MPKitAppboy brazeInstance], testClient);
+
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"userIdentificationType":@"CustomerId"
+                                       };
+
+    [appBoy didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    XCTAssertEqualObjects(appBoy.appboyInstance, testClient);
+    XCTAssertEqualObjects(appBoy.providerKitInstance, testClient);
+    XCTAssertEqualObjects([MPKitAppboy brazeInstance], testClient);
 }
 
 - (void)testUserIdCustomerId {


### PR DESCRIPTION
 ## Summary
Due to the partner SDK changes (from Appboy to Braze) the implementation changed a bit and the kit was no longer to fully handle attribution to Braze for notifications that open the app (cold start).

These changes allow customers to inform the kit that they will handle notifications in their app code as well as allowing them to set their own braze instance to the kit (which is required to handle notifications manually).

Docs updates will be forthcoming. 

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Heavily tested pairing with Michael G

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6148
