### PR TITLE
feat: Update to Braze 9.x.x SDK, improve privacy manifest support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,10 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "8.19.0")),
       .package(name: "braze-swift-sdk",
                url: "https://github.com/braze-inc/braze-swift-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "9.0.0")),
     ],
     targets: [
         .target(
@@ -31,7 +31,8 @@ let package = Package(
               .product(name: "BrazeUI", package: "braze-swift-sdk", condition: .when(platforms: [.iOS])),
               .product(name: "BrazeKit", package: "braze-swift-sdk"),
               .product(name: "BrazeKitCompat", package: "braze-swift-sdk"),
-            ]
+            ],
+            resources: [.process("PrivacyInfo.xcprivacy")]
         ),
         .target(
             name: "mParticle-Appboy-NoLocation",
@@ -41,7 +42,8 @@ let package = Package(
               .product(name: "BrazeKit", package: "braze-swift-sdk"),
               .product(name: "BrazeKitCompat", package: "braze-swift-sdk"),
             ],
-            path: "SPM/mParticle-Appboy-NoLocation"
+            path: "SPM/mParticle-Appboy-NoLocation",
+            resources: [.process("PrivacyInfo.xcprivacy")]
         )
     ]
 )

--- a/Sources/mParticle-Appboy/PrivacyInfo.xcprivacy
+++ b/Sources/mParticle-Appboy/PrivacyInfo.xcprivacy
@@ -7,12 +7,8 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -10,6 +10,13 @@
     #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
+#if defined(__has_include) && __has_include(<BrazeKit/BrazeKit-Swift.h>)
+    #import <BrazeKit/BrazeKit-Swift.h>
+#else
+    #import BrazeKit-Swift.h
+#endif
+
+
 @interface MPKitAppboy : NSObject <MPKitProtocol>
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
@@ -22,5 +29,6 @@
 #endif
 + (void)setURLDelegate:(nonnull id)delegate;
 + (void)setBrazeInstance:(nonnull id)instance;
-
++ (void)setBrazeLocationProvider:(nonnull id)instance;
++ (void)setBrazeTrackingPropertyAllowList:(nonnull NSSet<BRZTrackingProperty*> *)allowList;
 @end

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -17,16 +17,18 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "12.0"
     s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.0'
-    s.ios.dependency 'BrazeKit', '~> 8.0'
-    s.ios.dependency 'BrazeKitCompat', '~> 8.0'
-    s.ios.dependency 'BrazeUI', '~> 8.0'
+    s.ios.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
+    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.19'
+    s.ios.dependency 'BrazeKit', '~> 9.0'
+    s.ios.dependency 'BrazeKitCompat', '~> 9.0'
+    s.ios.dependency 'BrazeUI', '~> 9.0'
     
     s.tvos.deployment_target = "12.0"
     s.tvos.source_files      = 'Sources/**/*.{h,m,mm}'
-    s.tvos.dependency 'mParticle-Apple-SDK', '~> 8.0'
-    s.tvos.dependency 'BrazeKit', '~> 8.0'
-    s.tvos.dependency 'BrazeKitCompat', '~> 8.0'
+    s.tvos.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
+    s.tvos.dependency 'mParticle-Apple-SDK', '~> 8.19'
+    s.tvos.dependency 'BrazeKit', '~> 9.0'
+    s.tvos.dependency 'BrazeKitCompat', '~> 9.0'
 
 
 end

--- a/mParticle-Appboy.xcodeproj/project.pbxproj
+++ b/mParticle-Appboy.xcodeproj/project.pbxproj
@@ -141,7 +141,6 @@
 			children = (
 				DB76F1C925D2E71D00CAB3EB /* mParticle-Appboy */,
 				DB76F1CE25D2E71D00CAB3EB /* Info.plist */,
-				D344232F2B960F44006CD046 /* PrivacyInfo.xcprivacy */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -151,6 +150,7 @@
 			children = (
 				DB76F1CA25D2E71D00CAB3EB /* include */,
 				DB76F1CD25D2E71D00CAB3EB /* MPKitAppboy.m */,
+				D344232F2B960F44006CD046 /* PrivacyInfo.xcprivacy */,
 			);
 			path = "mParticle-Appboy";
 			sourceTree = "<group>";
@@ -921,7 +921,7 @@
 			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 9.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
 ## Summary
 - Updates Braze dependency to 9.x.x (required for privacy manifest changes)
 - Adds some new kit functionality to use the new Braze changes (will update docs tomorrow)
 - Fixed some new Swift warnings (errors?) around configuration parameters (that's why there's some more changes here than would seem necessary)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - E2E event smoke test up to Braze
 - Tested setting the tracking allow list from both a Swift and Obj-C app
 - Tested generating privacy reports using all three package managers

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6405
