### PR TITLE
fix: Setting urlDelegate on Braze instance

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -48,10 +48,10 @@ static NSString *const promotionKey = @"promotions";
 static NSString *const impressionKey = @"impressions";
 
 #if TARGET_OS_IOS
-__weak static id<BrazeInAppMessageUIDelegate> inAppMessageControllerDelegate = nil;
+static id<BrazeInAppMessageUIDelegate> inAppMessageControllerDelegate = nil;
 static BOOL shouldDisableNotificationHandling = NO;
 #endif
-__weak static id<BrazeDelegate> urlDelegate = nil;
+static id<BrazeDelegate> urlDelegate = nil;
 static Braze *brazeInstance = nil;
 static id brazeLocationProvider = nil;
 static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
@@ -367,6 +367,10 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     }
     [self->appboyInstance setAdTrackingEnabled:[self isAppTrackingEnabled]];
     
+    if ([MPKitAppboy urlDelegate]) {
+        self->appboyInstance.delegate = [MPKitAppboy urlDelegate];
+    }
+    
 #if TARGET_OS_IOS
     BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
     inAppMessageUI.delegate = [MPKitAppboy inAppMessageControllerDelegate];
@@ -446,10 +450,6 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
         }
     }
 #endif
-    
-    if ([MPKitAppboy urlDelegate]) {
-        optionsDictionary[ABKURLDelegateKey] = (NSObject *)[MPKitAppboy urlDelegate];
-    }
     
     return optionsDictionary;
 }

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -31,6 +31,7 @@
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     [MPKitAppboy setBrazeInstance:nil];
+    [MPKitAppboy setURLDelegate:nil];
 }
 
 - (void)tearDown {
@@ -261,7 +262,7 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testWeakMessageDelegate {
+- (void)testStrongMessageDelegate {
     id<BrazeInAppMessageUIDelegate> delegate = (id)[NSObject new];
     
     [MPKitAppboy setInAppMessageControllerDelegate:delegate];
@@ -271,7 +272,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        XCTAssertNil([MPKitAppboy inAppMessageControllerDelegate]);
+        XCTAssertNotNil([MPKitAppboy inAppMessageControllerDelegate]);
         [expectation fulfill];
     });
     


### PR DESCRIPTION
 ## Summary
 - We had a class method to set a Braze delegate, but it ultimately wasn't being set on the instance. This resolves that issue.
 - Also I made all delegates strong references as they're static anyway and weak can cause potential issues between setting and using depending on how the customer stores the reference.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed with breakpoints that it is correctly being set now.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6502
