### PR TITLE
fix: add forward screen events config when using an external Braze instance

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -366,6 +366,8 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
         self->forwardScreenViews = [self.configuration[@"forwardScreenViews"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
     }
     
+    self->collectIDFA = self.configuration[@"ABKCollectIDFA"] && [self.configuration[@"ABKCollectIDFA"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
+    
     if (self->collectIDFA) {
         [self->appboyInstance setIdentifierForAdvertiser:[self advertisingIdentifierString]];
     }
@@ -419,23 +421,11 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
         }
     }];
     
-    self->collectIDFA = self.configuration[@"ABKCollectIDFA"] && [self.configuration[@"ABKCollectIDFA"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
-    if (self->collectIDFA) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
-        optionsDictionary[ABKIDFADelegateKey] = (id)self;
-#pragma clang diagnostic pop
-    }
-    
     if (self.host.length) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
         optionsDictionary[ABKEndpointKey] = self.host;
 #pragma clang diagnostic pop
-    }
-    
-    if (self.configuration[@"forwardScreenViews"]) {
-        self->forwardScreenViews = [self.configuration[@"forwardScreenViews"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
     }
     
     if (optionsDictionary.count == 0) {

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -362,9 +362,7 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
         return;
     }
     
-    if (self.configuration[@"forwardScreenViews"]) {
-        self->forwardScreenViews = [self.configuration[@"forwardScreenViews"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
-    }
+    self->forwardScreenViews = self.configuration[@"forwardScreenViews"] && [self.configuration[@"forwardScreenViews"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
     
     self->collectIDFA = self.configuration[@"ABKCollectIDFA"] && [self.configuration[@"ABKCollectIDFA"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
     

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -362,6 +362,10 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
         return;
     }
     
+    if (self.configuration[@"forwardScreenViews"]) {
+        self->forwardScreenViews = [self.configuration[@"forwardScreenViews"] caseInsensitiveCompare:@"true"] == NSOrderedSame;
+    }
+    
     if (self->collectIDFA) {
         [self->appboyInstance setIdentifierForAdvertiser:[self advertisingIdentifierString]];
     }


### PR DESCRIPTION
 ## Summary
The change allows the kit to set if the screen events should be forwarded to Braze using the mP config data when the Braze Instance is initialized externally and then set as the appboy kit instance.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.

I tested it manually.
Before the change:

<img width="678" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/d5c2e04e-368c-4d2e-b8ad-d9465c89382c">

After the change:
<img width="698" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/assets/136605018/19bb4ca5-bcbc-4964-b413-205aaefdc6aa">


