### PR TITLE
fix: Kit fails to start due to missing kitApi property

### DIFF
--- a/Sources/mParticle-Appboy/include/MPKitAppboy.h
+++ b/Sources/mParticle-Appboy/include/MPKitAppboy.h
@@ -22,6 +22,7 @@
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
+@property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 
 #if TARGET_OS_IOS
 + (void)setInAppMessageControllerDelegate:(nonnull id)delegate;


### PR DESCRIPTION
Confirmed working now in test app, tested event flow to kit and confirmed the kitApi property has a value.
