### PR TITLE
fix: update Braze Version for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                .upToNextMajor(from: "8.19.0")),
       .package(name: "braze-swift-sdk",
                url: "https://github.com/braze-inc/braze-swift-sdk",
-               .upToNextMajor(from: "9.0.0")),
+               .upToNextMajor(from: "10.0.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
 - Updated SPM to use latest version of Braze

 ## Testing Plan
 - Confirmed locally

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
