### PR TITLE
fix: Update Consent When Kit Is Initialized

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -334,9 +334,6 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
         _started = NO;
     }
     
-    // Update Consent on launch
-    [self updateConsent];
-    
     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;
 }
@@ -397,6 +394,9 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     [self updateUser:currentUser request:currentUser.userIdentities];
     
     self->_started = YES;
+    
+    // Update Consent on start
+    [self updateConsent];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - The `updateConsent` is now called after the kit is initialized so that the mapping of the consent attributes is done correctly with an active kit.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - Set a breakpoint in the mapping of the consent attributes to evaluate the status of the kit (NOT nil)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6864
