### PR TITLE
fix: prevent mpid with value 0 to forward to Braze

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -391,7 +391,9 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
 #endif
     
     FilteredMParticleUser *currentUser = [[self kitApi] getCurrentUserWithKit:self];
-    [self updateUser:currentUser request:currentUser.userIdentities];
+    if (currentUser.userId.integerValue != 0) {
+        [self updateUser:currentUser request:currentUser.userIdentities];
+    }
     
     self->_started = YES;
     

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -18,6 +18,7 @@
 - (void)setEnableTypeDetection:(BOOL)enableTypeDetection;
 + (BOOL)shouldDisableNotificationHandling;
 + (Braze *)brazeInstance;
++ (MPKitExecStatus *)updateUser:(FilteredMParticleUser *)user request:(NSDictionary<NSNumber *,NSString *> *)userIdentities;
 
 @end
 
@@ -82,6 +83,93 @@
     
     NSDictionary *optionsDictionary = [appBoy optionsDictionary];
     XCTAssertEqualObjects(optionsDictionary, testOptionsDictionary);
+}
+
+- (void)testMpidForwardingOnStartUserIdZero {
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"userIdentificationType":@"MPID"
+                                       };
+    
+    MPKitAppboy *kitInstance = [[MPKitAppboy alloc] init];
+    
+    [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    MParticleUser *testUser = [[MParticleUser alloc] init];
+    [testUser setValue:@(0) forKey:@"userId"];
+    
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:testUser kitConfiguration:kitConfiguration];
+    id mockKitApi = OCMClassMock([MPKitAPI class]);
+    OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
+    kitInstance.kitApi = mockKitApi;
+    
+    id mockKitInstance = OCMPartialMock(kitInstance);
+    [[mockKitInstance reject] updateUser:[OCMArg any] request:[OCMArg any]];
+    [kitInstance start];
+    [mockKitInstance verify];
+}
+
+- (void)testMpidForwardingOnStartUserIdPositive {
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"userIdentificationType":@"MPID"
+                                       };
+    
+    MPKitAppboy *kitInstance = [[MPKitAppboy alloc] init];
+    
+    [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    MParticleUser *testUser = [[MParticleUser alloc] init];
+    [testUser setValue:@(1) forKey:@"userId"];
+    
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:testUser kitConfiguration:kitConfiguration];
+    id mockKitApi = OCMClassMock([MPKitAPI class]);
+    OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
+    kitInstance.kitApi = mockKitApi;
+    
+    id mockKitInstance = OCMPartialMock(kitInstance);
+    [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
+    [kitInstance start];
+    [mockKitInstance verify];
+}
+
+- (void)testMpidForwardingOnStartUserIdNegative {
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"userIdentificationType":@"MPID"
+                                       };
+    
+    MPKitAppboy *kitInstance = [[MPKitAppboy alloc] init];
+    
+    [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    MParticleUser *testUser = [[MParticleUser alloc] init];
+    [testUser setValue:@(-1) forKey:@"userId"];
+    
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:testUser kitConfiguration:kitConfiguration];
+    id mockKitApi = OCMClassMock([MPKitAPI class]);
+    OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
+    kitInstance.kitApi = mockKitApi;
+    
+    id mockKitInstance = OCMPartialMock(kitInstance);
+    [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
+    [kitInstance start];
+    [mockKitInstance verify];
 }
 
 //- (void)testEndpointOverride {


### PR DESCRIPTION
 ## Summary
 - A customer have recently noticed that they have a profile in Braze with value 0 where they have in their configuration to forward the MPID as the external identity. We were able to reproduce with only apps built with Obj C while swift apps didn't reproduce the issue. After further further investigation we noticed that we create in our identityAPI an MParticleUser with MPID = 0 on first installs before mParticle is initialized and forward it to Braze.

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - E2E tested with enabling Braze logs where the Braze message "Changed to user 0" stopped appearing with the fix
 - Unit tests were also included for cases where MPID is zero, positive or negative

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6897
