### PR TITLE
feat: Add SendProductName Option to Braze

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -16,6 +16,7 @@ static NSString *const userIdTypeKey = @"userIdentificationType";
 static NSString *const emailIdTypeKey = @"emailIdentificationType";
 static NSString *const enableTypeDetectionKey = @"enableTypeDetection";
 static NSString *const bundleCommerceEventData = @"bundleCommerceEventData";
+static NSString *const replaceSkuAsProductName = @"forwardSkuAsProductName";
 
 // The possible values for userIdentificationType
 static NSString *const userIdValueOther = @"Other";
@@ -550,11 +551,16 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
                     [properties addEntriesFromDictionary:productDictionary];
                 }
                 
+                NSString *sanitizedProductName = product.sku;
+                if ([@"True" isEqualToString:_configuration[replaceSkuAsProductName]]) {
+                    sanitizedProductName = product.name;
+                }
+                
                 // Strips key/values already being passed to Appboy, plus key/values initialized to default values
                 keys = @[kMPExpProductSKU, kMPProductCurrency, kMPExpProductUnitPrice, kMPExpProductQuantity];
                 [properties removeObjectsForKeys:keys];
                 
-                [appboyInstance logPurchase:product.sku
+                [appboyInstance logPurchase:sanitizedProductName
                                    currency:currency
                                       price:[product.price doubleValue]
                                    quantity:[product.quantity integerValue]


### PR DESCRIPTION
## Summary
 - Added a check for the optional flag to send product name rather than sku

 ## Testing Plan
 - Tested with QA on simulator and added unit test

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6887
