### PR TITLE
fix: Bump min Braze SDK to 11.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                .upToNextMajor(from: "8.19.0")),
       .package(name: "braze-swift-sdk",
                url: "https://github.com/braze-inc/braze-swift-sdk",
-               .upToNextMajor(from: "11.0.0")),
+               .upToNextMajor(from: "11.2.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -19,16 +19,16 @@ Pod::Spec.new do |s|
     s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK', '~> 8.19'
-    s.ios.dependency 'BrazeKit', '~> 11.0'
-    s.ios.dependency 'BrazeKitCompat', '~> 11.0'
-    s.ios.dependency 'BrazeUI', '~> 11.0'
+    s.ios.dependency 'BrazeKit', '~> 11.2'
+    s.ios.dependency 'BrazeKitCompat', '~> 11.2'
+    s.ios.dependency 'BrazeUI', '~> 11.2'
     
     s.tvos.deployment_target = "12.0"
     s.tvos.source_files      = 'Sources/**/*.{h,m,mm}'
     s.tvos.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
     s.tvos.dependency 'mParticle-Apple-SDK', '~> 8.19'
-    s.tvos.dependency 'BrazeKit', '~> 11.0'
-    s.tvos.dependency 'BrazeKitCompat', '~> 11.0'
+    s.tvos.dependency 'BrazeKit', '~> 11.2'
+    s.tvos.dependency 'BrazeKitCompat', '~> 11.2'
 
 
 end


### PR DESCRIPTION
 ## Summary
Braze informed us that versions 11.0 and 11.1 have a critical bug and requested that we raise our minimum dependency version to 11.2.

Note that we were already pinned up to next major, so version 11.2 and above would be pulled in automatically when updating, so this is just an extra precaution.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.

Smoke tested in both a CocoaPods and SPM project and ran `pod lib lint` locally to confirm the podspec.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6931
