### PR TITLE
fix: Update Braze to 11.9 to include iCloud restore fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                .upToNextMajor(from: "8.19.0")),
       .package(name: "braze-swift-sdk",
                url: "https://github.com/braze-inc/braze-swift-sdk",
-               .upToNextMajor(from: "11.2.0")),
+               .upToNextMajor(from: "11.9.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -19,16 +19,16 @@ Pod::Spec.new do |s|
     s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK', '~> 8.19'
-    s.ios.dependency 'BrazeKit', '~> 11.2'
-    s.ios.dependency 'BrazeKitCompat', '~> 11.2'
-    s.ios.dependency 'BrazeUI', '~> 11.2'
+    s.ios.dependency 'BrazeKit', '~> 11.9'
+    s.ios.dependency 'BrazeKitCompat', '~> 11.9'
+    s.ios.dependency 'BrazeUI', '~> 11.9'
     
     s.tvos.deployment_target = "12.0"
     s.tvos.source_files      = 'Sources/**/*.{h,m,mm}'
     s.tvos.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
     s.tvos.dependency 'mParticle-Apple-SDK', '~> 8.19'
-    s.tvos.dependency 'BrazeKit', '~> 11.2'
-    s.tvos.dependency 'BrazeKitCompat', '~> 11.2'
+    s.tvos.dependency 'BrazeKit', '~> 11.9'
+    s.tvos.dependency 'BrazeKitCompat', '~> 11.9'
 
 
 end


### PR DESCRIPTION
 ## Summary
 - From Braze: Hi mParticle! We recently released an important fix in Braze Swift SDK 11.6.1 that impacts how Braze handles iCloud restore. Could we ask that you bump your integration to (preferably) Braze Swift SDK version 11.9.0, or at least 11.6.1 please?

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7173
