### PR TITLE
feat: Add support to forward SubscriptionGroupIds

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -17,6 +17,7 @@ static NSString *const emailIdTypeKey = @"emailIdentificationType";
 static NSString *const enableTypeDetectionKey = @"enableTypeDetection";
 static NSString *const bundleCommerceEventData = @"bundleCommerceEventData";
 static NSString *const replaceSkuWithProductName = @"replaceSkuWithProductName";
+static NSString *const subscriptionGroupMapping = @"subscriptionGroupMapping";
 
 // The possible values for userIdentificationType
 static NSString *const userIdValueOther = @"Other";
@@ -72,6 +73,7 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     Braze *appboyInstance;
     BOOL collectIDFA;
     BOOL forwardScreenViews;
+    NSMutableDictionary *subscriptionGroupDictionary;
 }
 
 @property (nonatomic) NSString *host;
@@ -178,6 +180,27 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     } else {
         return originalString;
     }
+}
+
+- (NSMutableDictionary *)getSubscriptionGroupIds:(NSString *)subscriptionGroupMap {
+    NSMutableDictionary *subsctiprionGroupDictionary = [NSMutableDictionary dictionary];
+    
+    if (!subscriptionGroupMap.length) {
+        return subsctiprionGroupDictionary;
+    }
+    
+    NSData *subsctiprionGroupData = [subscriptionGroupMap dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSError *error = nil;
+    NSArray *subsctiprionGroupDataArray = [NSJSONSerialization JSONObjectWithData:subsctiprionGroupData options:0 error:&error];
+
+    for (NSDictionary *item in subsctiprionGroupDataArray) {
+        NSString *key = item[@"map"];
+        NSString *value = item[@"value"];
+        subsctiprionGroupDictionary[key] = value;
+    }
+
+    return subsctiprionGroupDictionary;
 }
 
 - (MPKitExecStatus *)logAppboyCustomEvent:(MPEvent *)event eventType:(NSUInteger)eventType {
@@ -386,6 +409,8 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     if ([MPKitAppboy urlDelegate]) {
         self->appboyInstance.delegate = [MPKitAppboy urlDelegate];
     }
+    
+    self->subscriptionGroupDictionary = [self getSubscriptionGroupIds:self.configuration[subscriptionGroupMapping]];
     
 #if TARGET_OS_IOS
     BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
@@ -708,6 +733,7 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     }
     
     value = [self stringRepresentation:value];
+    
     if (!value) {
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeFail];
         return execStatus;
@@ -819,6 +845,17 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
             [appboyInstance.user setPushNotificationSubscriptionState:BRZUserSubscriptionStateSubscribed];
         } else {
             NSLog(@"mParticle -> Invalid push_subscribe value: %@", value);
+            execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeFail];
+            return execStatus;
+        }
+    } else if (subscriptionGroupDictionary[key]){
+        NSString *subscriptionGroupId = subscriptionGroupDictionary[key];
+        if ([value isEqualToString:@"1"]) {
+            [appboyInstance.user addToSubscriptionGroupWithGroupId:subscriptionGroupId];
+        } else if ([value isEqualToString:@"0"]) {
+            [appboyInstance.user removeFromSubscriptionGroupWithGroupId:subscriptionGroupId];
+        } else {
+            NSLog(@"mParticle -> Invalid value type for subscriptionGroupId mapped user attribute key: %@, expected value should be of type BOOL", key);
             execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeFail];
             return execStatus;
         }

--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -183,10 +183,10 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
 }
 
 - (NSMutableDictionary *)getSubscriptionGroupIds:(NSString *)subscriptionGroupMap {
-    NSMutableDictionary *subsctiprionGroupDictionary = [NSMutableDictionary dictionary];
+    NSMutableDictionary *subscriptionGroupDictionary = [NSMutableDictionary dictionary];
     
     if (!subscriptionGroupMap.length) {
-        return subsctiprionGroupDictionary;
+        return subscriptionGroupDictionary;
     }
     
     NSData *subsctiprionGroupData = [subscriptionGroupMap dataUsingEncoding:NSUTF8StringEncoding];
@@ -197,10 +197,10 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
     for (NSDictionary *item in subsctiprionGroupDataArray) {
         NSString *key = item[@"map"];
         NSString *value = item[@"value"];
-        subsctiprionGroupDictionary[key] = value;
+        subscriptionGroupDictionary[key] = value;
     }
 
-    return subsctiprionGroupDictionary;
+    return subscriptionGroupDictionary;
 }
 
 - (MPKitExecStatus *)logAppboyCustomEvent:(MPEvent *)event eventType:(NSUInteger)eventType {

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -234,6 +234,42 @@
     [mockClient stopMocking];
 }
 
+- (void)testSubscriptionGroupIdsMappedUserAttributes {
+    NSDictionary *kitConfiguration = @{@"apiKey":@"BrazeID",
+                                       @"id":@42,
+                                       @"ABKCollectIDFA":@"true",
+                                       @"ABKRequestProcessingPolicyOptionKey": @"1",
+                                       @"ABKFlushIntervalOptionKey":@"2",
+                                       @"ABKSessionTimeoutKey":@"3",
+                                       @"ABKMinimumTriggerTimeIntervalKey":@"4",
+                                       @"userIdentificationType":@"MPID",
+                                       @"subscriptionGroupMapping" : @"[{\"jsmap\":null,\"map\":\"testAttribute1\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"00000000-0000-0000-0000-00000000000\"},{\"jsmap\":null,\"map\":\"testAttribute2\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"00000000-0000-0000-0000-00000000001\"}]"
+                                       };
+    
+    MPKitAppboy *kitInstance = [[MPKitAppboy alloc] init];
+    [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
+    
+    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
+    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
+    id mockClient = OCMPartialMock(testClient);
+    [kitInstance setAppboyInstance:mockClient];
+    XCTAssertEqualObjects(mockClient, [kitInstance appboyInstance]);
+    
+    // Should succeed since Bool false is a valid value
+    MPKitExecStatus *execStatus1 = [kitInstance setUserAttribute:@"testAttribute1" value:@NO];
+    XCTAssertEqual(execStatus1.returnCode, MPKitReturnCodeSuccess);
+    // Should succeed since Bool true is a valid value
+    MPKitExecStatus *execStatus2 = [kitInstance setUserAttribute:@"testAttribute2" value:@YES];
+    XCTAssertEqual(execStatus2.returnCode, MPKitReturnCodeSuccess);
+    // Should fail since testValue is not type BOOL
+    MPKitExecStatus *execStatus3 = [kitInstance setUserAttribute:@"testAttribute2" value:@"testValue"];
+    XCTAssertEqual(execStatus3.returnCode, MPKitReturnCodeFail);
+
+    [mockClient verify];
+
+    [mockClient stopMocking];
+}
+
 
 //- (void)testEndpointOverride {
 //    MPKitAppboy *appBoy = [[MPKitAppboy alloc] init];


### PR DESCRIPTION
 ## Summary
 - We currently support forwarding subscriptionGroupIds mapped via user attributes in our Braze S2S forwarder only, a customer mentioned that Braze support this feature in their Braze and requested this as a feature to our kits, refer to our [docs](https://docs.mparticle.com/integrations/braze/event/#subscription-groups) regarding subscription group ids

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7211
