### PR TITLE
fix: Forward commerce event custom attributes for purchase

### DIFF
--- a/Sources/mParticle-Appboy/MPKitAppboy.m
+++ b/Sources/mParticle-Appboy/MPKitAppboy.m
@@ -534,6 +534,11 @@ static NSSet<BRZTrackingProperty*> *brazeTrackingPropertyAllowList;
             }
         }
         
+        NSDictionary *commerceCustomAttribues = [commerceEvent.customAttributes transformValuesToString];
+        for (NSString *key in commerceCustomAttribues) {
+            baseProductAttributes[key] = commerceCustomAttribues[key];
+        }
+        
         NSArray *products = commerceEvent.products;
         NSString *currency = commerceEvent.currency ? : @"USD";
         NSMutableDictionary *properties;

--- a/mParticle_AppboyTests/mParticle_AppboyTests.m
+++ b/mParticle_AppboyTests/mParticle_AppboyTests.m
@@ -667,7 +667,8 @@
                                        @"Tax Amount" : @3,
                                        @"Transaction Id" : @"foo-transaction-id",
                                        @"Name" : @"product1",
-                                       @"Category" : @"category1"
+                                       @"Category" : @"category1",
+                                       @"testKey" : @"testCustomAttValue"
                        }];
 
     MPKitExecStatus *execStatus = [kit logBaseEvent:event];
@@ -715,7 +716,8 @@
                                        @"Tax Amount" : @3,
                                        @"Transaction Id" : @"foo-transaction-id",
                                        @"Name" : @"product1",
-                                       @"Category" : @"category1"
+                                       @"Category" : @"category1",
+                                       @"testKey" : @"testCustomAttValue"
                        }];
 
     MPKitExecStatus *execStatus = [kit logBaseEvent:event];


### PR DESCRIPTION
 ## Summary
 - A customer noticed that we don't send event level custom attributes for purchase events while the Android Braze kit does, this PR allows forwarding them to Braze for iOS

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and Unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7359
