### PR TITLE
chore: Update to Version 9.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.19.0")),
+               .upToNextMajor(from: "9.0.0")),
       .package(name: "braze-swift-sdk",
                url: "https://github.com/braze-inc/braze-swift-sdk",
                .upToNextMajor(from: "12.0.0")),

--- a/mParticle-Appboy.podspec
+++ b/mParticle-Appboy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Appboy"
-    s.version          = "8.13.2"
+    s.version          = "9.0.0"
     s.summary          = "Appboy integration for mParticle"
 
     s.description      = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "12.0"
     s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.19'
+    s.ios.dependency 'mParticle-Apple-SDK', '~> 9.0'
     s.ios.dependency 'BrazeKit', '~> 12.0'
     s.ios.dependency 'BrazeKitCompat', '~> 12.0'
     s.ios.dependency 'BrazeUI', '~> 12.0'
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = "12.0"
     s.tvos.source_files      = 'Sources/**/*.{h,m,mm}'
     s.tvos.resource_bundles  = { 'mParticle-Appboy-Privacy' => ['Sources/mParticle-Appboy/PrivacyInfo.xcprivacy'] }
-    s.tvos.dependency 'mParticle-Apple-SDK', '~> 8.19'
+    s.tvos.dependency 'mParticle-Apple-SDK', '~> 9.0'
     s.tvos.dependency 'BrazeKit', '~> 12.0'
     s.tvos.dependency 'BrazeKitCompat', '~> 12.0'
 


### PR DESCRIPTION
## Summary
 - Bumps the integration version from 8.11.1 to 9.0.0
 - Updates the mParticle-Apple-SDK dependency to ~> 9.0 for both iOS and tvOS platforms in the podspec
 - Updates the Swift Package Manager dependency to .upToNextMajor(from: "9.0.0") in Package.swift

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-773
